### PR TITLE
Add checksum verification to install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-REPO="claudeup/claudeup-lab"
-INSTALL_DIR="${HOME}/.local/bin"
-BINARY="claudeup-lab"
+readonly REPO="claudeup/claudeup-lab"
+readonly INSTALL_DIR="${HOME}/.local/bin"
+readonly BINARY="claudeup-lab"
 
 TEMP_DIR=""
 cleanup() {
     [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
 }
 trap cleanup EXIT
+trap 'echo "Error on line $LINENO" >&2; exit 1' ERR
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
+case "$OS" in
+    linux|darwin) ;;
+    *) echo "Unsupported operating system: $OS" >&2; exit 1 ;;
+esac
 case "$ARCH" in
     x86_64) ARCH="amd64" ;;
     aarch64|arm64) ARCH="arm64" ;;
@@ -22,23 +27,34 @@ esac
 
 # Get version (override with VERSION env var)
 if [[ -z "${VERSION:-}" ]]; then
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/')
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v?([^"]+)".*/\1/') || true
 fi
 if [[ -z "$VERSION" ]]; then
-    VERSION="0.1.0"
+    echo "Failed to detect latest version from GitHub API." >&2
+    echo "Set VERSION explicitly: VERSION=0.2.0 bash scripts/install.sh" >&2
+    exit 1
 fi
 
-ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
-BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
+readonly ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
+readonly BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
 
 echo "Downloading ${BINARY} v${VERSION} for ${OS}-${ARCH}..."
 
 TEMP_DIR=$(mktemp -d)
-curl -fsSL -o "${TEMP_DIR}/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
-curl -fsSL -o "${TEMP_DIR}/checksums.txt" "${BASE_URL}/checksums.txt"
+
+if ! curl -fsSL -o "${TEMP_DIR}/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"; then
+    echo "Failed to download ${BASE_URL}/${ARCHIVE}" >&2
+    echo "Check that version v${VERSION} exists and has a release for ${OS}-${ARCH}" >&2
+    exit 1
+fi
+
+if ! curl -fsSL -o "${TEMP_DIR}/checksums.txt" "${BASE_URL}/checksums.txt"; then
+    echo "Failed to download checksums file from ${BASE_URL}/checksums.txt" >&2
+    exit 1
+fi
 
 # Verify checksum
-EXPECTED=$(grep "${ARCHIVE}" "${TEMP_DIR}/checksums.txt" | awk '{print $1}')
+EXPECTED=$(awk -v f="${ARCHIVE}" '$2 == f {print $1}' "${TEMP_DIR}/checksums.txt")
 if [[ -z "$EXPECTED" ]]; then
     echo "No checksum found for ${ARCHIVE} in checksums.txt" >&2
     exit 1
@@ -60,10 +76,14 @@ if [[ "$EXPECTED" != "$ACTUAL" ]]; then
     exit 1
 fi
 
-# Extract and install atomically
-tar xz -C "$TEMP_DIR" -f "${TEMP_DIR}/${ARCHIVE}" "$BINARY"
+# Extract and install
+if ! tar xz -C "$TEMP_DIR" -f "${TEMP_DIR}/${ARCHIVE}" "$BINARY"; then
+    echo "Failed to extract ${BINARY} from ${ARCHIVE}" >&2
+    exit 1
+fi
+
 mkdir -p "$INSTALL_DIR"
-mv "${TEMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+install -m 755 "${TEMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
 
 echo "Installed ${BINARY} v${VERSION} to ${INSTALL_DIR}/${BINARY}"
 


### PR DESCRIPTION
## Summary
- Downloads `checksums.txt` from the release and verifies SHA-256 hash before extracting the archive
- Extracts to a temp directory and moves binary into place atomically, preventing partial installs
- Detects `sha256sum` (Linux) or `shasum -a 256` (macOS) for portable hashing
- Adds cleanup trap and stricter bash mode (`set -Eeuo pipefail`)

Closes #3

## Test plan
- [x] Verified against real v0.1.0 release -- checksum matched, binary installed successfully
- [x] Confirmed installed binary runs (`claudeup-lab version` returns `0.1.0`)
- [x] Verified mismatch detection with tampered checksums
- [ ] Test on Linux (sha256sum path)