### PR TITLE
Pin Bun and Claude CLI versions with checksum verification

### DIFF
--- a/docs/superpowers/plans/2026-03-14-dockerfile-version-pinning.md
+++ b/docs/superpowers/plans/2026-03-14-dockerfile-version-pinning.md
@@ -4,7 +4,7 @@
 
 **Goal:** Pin Bun and Claude CLI versions in the embedded Dockerfile with SHA-256 checksum verification.
 
-**Architecture:** Replace the two `curl | bash` install lines with direct artifact downloads, checksum verification via `sha256sum`, and manual binary placement. Single file change to `embed/Dockerfile`.
+**Architecture:** Replace the two piped install scripts with direct artifact downloads, checksum verification via `sha256sum`, and manual binary placement with multi-arch support (x64/arm64). Code change to `embed/Dockerfile`.
 
 **Tech Stack:** Docker, sha256sum, curl, unzip
 
@@ -64,12 +64,20 @@ With:
 
 ```dockerfile
 ARG BUN_VERSION=1.3.10
-ARG BUN_SHA256=f57bc0187e39623de716ba3a389fda5486b2d7be7131a980ba54dc7b733d2e08
-RUN curl -fsSL -o /tmp/bun.zip \
-        "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" \
+ARG BUN_SHA256_X64=f57bc0187e39623de716ba3a389fda5486b2d7be7131a980ba54dc7b733d2e08
+ARG BUN_SHA256_ARM64=fa5ecb25cafa8e8f5c87a0f833719d46dd0af0a86c7837d806531212d55636d3
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then \
+        BUN_ARCH="x64"; BUN_SHA256="${BUN_SHA256_X64}"; \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        BUN_ARCH="aarch64"; BUN_SHA256="${BUN_SHA256_ARM64}"; \
+    else echo "Unsupported architecture: $ARCH" >&2; exit 1; fi \
+    && curl -fsSL -o /tmp/bun.zip \
+        "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" \
     && echo "${BUN_SHA256}  /tmp/bun.zip" | sha256sum -c - \
     && mkdir -p /home/node/.bun/bin \
     && unzip -j /tmp/bun.zip "*/bun" -d /home/node/.bun/bin \
+    && test -f /home/node/.bun/bin/bun \
     && chmod 755 /home/node/.bun/bin/bun \
     && rm -f /tmp/bun.zip
 ```
@@ -101,9 +109,16 @@ With:
 
 ```dockerfile
 ARG CLAUDE_VERSION=2.1.76
-ARG CLAUDE_SHA256=801a085676c3d54392c42e8e43c44947df7c52132356575f7d9267c4f22d6992
-RUN curl -fsSL -o /tmp/claude \
-        "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${CLAUDE_VERSION}/linux-x64/claude" \
+ARG CLAUDE_SHA256_X64=801a085676c3d54392c42e8e43c44947df7c52132356575f7d9267c4f22d6992
+ARG CLAUDE_SHA256_ARM64=40f753c07f070df34ca83e400f746a8279a3fd343967a453d9fbfab2f3ca7acd
+RUN ARCH=$(uname -m) \
+    && if [ "$ARCH" = "x86_64" ]; then \
+        CLAUDE_ARCH="x64"; CLAUDE_SHA256="${CLAUDE_SHA256_X64}"; \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        CLAUDE_ARCH="arm64"; CLAUDE_SHA256="${CLAUDE_SHA256_ARM64}"; \
+    else echo "Unsupported architecture: $ARCH" >&2; exit 1; fi \
+    && curl -fsSL -o /tmp/claude \
+        "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${CLAUDE_VERSION}/linux-${CLAUDE_ARCH}/claude" \
     && echo "${CLAUDE_SHA256}  /tmp/claude" | sha256sum -c - \
     && install -m 755 /tmp/claude /home/node/.local/bin/claude \
     && rm /tmp/claude
@@ -149,7 +164,7 @@ Expected: Output contains `2.1.76`
 Temporarily change one character in `BUN_SHA256` and rebuild:
 
 ```bash
-docker build --build-arg BUN_SHA256=0000000000000000000000000000000000000000000000000000000000000000 -t claudeup-lab-test:bad embed/
+docker build --build-arg BUN_SHA256_ARM64=0000000000000000000000000000000000000000000000000000000000000000 --build-arg BUN_SHA256_X64=0000000000000000000000000000000000000000000000000000000000000000 -t claudeup-lab-test:bad embed/
 ```
 
 Expected: Build fails with `sha256sum: WARNING: 1 computed checksum did NOT match`

--- a/docs/superpowers/specs/2026-03-14-dockerfile-version-pinning-design.md
+++ b/docs/superpowers/specs/2026-03-14-dockerfile-version-pinning-design.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The embedded Dockerfile fetches and runs remote install scripts for Bun and Claude CLI without version pinning or checksum verification (`embed/Dockerfile` lines 44, 49). This makes builds non-reproducible and carries supply-chain risk from unverified binaries.
+The embedded Dockerfile fetches and runs remote install scripts for Bun and Claude CLI without version pinning or checksum verification. This makes builds non-reproducible and carries supply-chain risk from unverified binaries.
 
 ## Decision
 
@@ -44,9 +44,9 @@ The `ARG` declarations go immediately before their corresponding `RUN` layer, af
 
 ## Scope
 
-- **Changed file**: `embed/Dockerfile` only
+- **Code change**: `embed/Dockerfile` only
 - **No Go code changes**: The Dockerfile is a static embedded asset; `buildFallback()` in `image.go` does not pass `--build-arg` flags and does not need to
-- **No new files**: No helper scripts or verification utilities
+- **No new helper scripts or verification utilities**
 
 ## Version Selection
 

--- a/embed/Dockerfile
+++ b/embed/Dockerfile
@@ -47,7 +47,7 @@ ARG BUN_SHA256_ARM64=fa5ecb25cafa8e8f5c87a0f833719d46dd0af0a86c7837d806531212d55
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then \
         BUN_ARCH="x64"; BUN_SHA256="${BUN_SHA256_X64}"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
         BUN_ARCH="aarch64"; BUN_SHA256="${BUN_SHA256_ARM64}"; \
     else echo "Unsupported architecture: $ARCH" >&2; exit 1; fi \
     && curl -fsSL -o /tmp/bun.zip \
@@ -68,7 +68,7 @@ ARG CLAUDE_SHA256_ARM64=40f753c07f070df34ca83e400f746a8279a3fd343967a453d9fbfab2
 RUN ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then \
         CLAUDE_ARCH="x64"; CLAUDE_SHA256="${CLAUDE_SHA256_X64}"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
         CLAUDE_ARCH="arm64"; CLAUDE_SHA256="${CLAUDE_SHA256_ARM64}"; \
     else echo "Unsupported architecture: $ARCH" >&2; exit 1; fi \
     && curl -fsSL -o /tmp/claude \


### PR DESCRIPTION
## Summary

- Replace piped install scripts with direct binary downloads and SHA-256 checksum verification for both Bun (v1.3.10) and Claude CLI (v2.1.76)
- Support both x64 and arm64 architectures via runtime detection
- Add unzip to apt-get for Bun archive extraction

## Test Plan

- [x] Docker build succeeds with both checksums verified
- [x] bun --version returns 1.3.10
- [x] claude --version returns 2.1.76
- [x] Deliberately wrong checksum fails the build
- [x] All existing Go tests pass

Closes #4