### PR TITLE
docs: add FAQ entries for container isolation and profile scoping

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,7 +58,7 @@ The bare repo clone is always mounted at its host path so that git worktree reso
 
 No. The container's `~/.claude` is a fresh Docker volume (`claudeup-lab-config-{id}`), not a bind mount of your host directory. Your host `~/.claude` is never mounted into the container.
 
-What does get carried in from the host:
+What does get carried in from the host (each is a conditional bind mount, only added if the source exists):
 
 - `~/.claudeup/profiles` (readonly) -- so named and snapshot profiles are available for the entrypoint to apply
 - `~/.claudeup/ext` (readonly) -- your extensions


### PR DESCRIPTION
## Summary

- Add FAQ entry clarifying that the container gets a fresh `~/.claude` volume (not a bind mount of the host directory), what host paths do get mounted, and how to start a lab without the current config snapshot
- Add FAQ entry explaining the difference between `--profile` and `--base-profile`, including scope assignment (user vs project), snapshot behavior, and a summary table of all flag combinations

## Test plan

- [ ] Verify FAQ renders correctly on GitHub
- [ ] Confirm technical details match `init-claudeup.sh` entrypoint behavior and `manager.go` snapshot logic