### PR TITLE
fix: stream devcontainer output instead of buffering

### DIFF
--- a/internal/lab/manager.go
+++ b/internal/lab/manager.go
@@ -1,7 +1,6 @@
 package lab
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -148,13 +147,11 @@ func (m *Manager) Start(opts *StartOptions) (*Metadata, error) {
 	}
 
 	// Launch container
-	fmt.Println("Starting devcontainer (this may take a minute)...")
-	var devOutput bytes.Buffer
+	fmt.Println("Starting devcontainer...")
 	devCmd := exec.Command("devcontainer", "up", "--workspace-folder", worktreePath)
-	devCmd.Stdout = &devOutput
-	devCmd.Stderr = &devOutput
+	devCmd.Stdout = os.Stdout
+	devCmd.Stderr = os.Stderr
 	if err := devCmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "\n--- devcontainer output ---\n%s\n", devOutput.String())
 		m.worktrees.RemoveWorktree(barePath, worktreePath)
 		return nil, fmt.Errorf("devcontainer up: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Stream `devcontainer up` stdout/stderr directly to the terminal instead of capturing into a buffer
- Previously, all postCreateCommand output (init scripts, package installs, profile application) was invisible until failure, making the process appear hung

## Test plan
- [ ] Run `claudeup-lab start` and verify init script output is visible in real-time
- [ ] Verify error output still appears on failure