### PR TITLE
feat: add preset system for saving and reusing lab configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 **/CLAUDE.md
 bin/
 .env
+backlog/
+BUSINESS.md
+DESIGN.md
+ARCHITECTURE.md
+TRASH/
+TRASH-FILES.md

--- a/README.md
+++ b/README.md
@@ -58,21 +58,41 @@ claudeup-lab stop --lab myproject-experimental
 
 # Destroy a lab completely
 claudeup-lab rm --lab myproject-experimental
+
+# Save a lab's configuration as a reusable preset
+claudeup-lab preset save my-config --from-lab myproject-experimental
+
+# Start a lab from a saved preset
+claudeup-lab start my-config
+
+# Start with overrides
+claudeup-lab start my-config --branch lab/experiment
+
+# List saved presets
+claudeup-lab preset list
+
+# View preset details
+claudeup-lab preset show my-config
 ```
 
 ## Commands
 
-| Command  | Description                           |
-| -------- | ------------------------------------- |
-| `start`  | Create and start a lab                |
-| `list`   | Show all labs and their status        |
-| `exec`   | Run a command inside a running lab    |
-| `open`   | Attach VS Code to a running lab       |
-| `stop`   | Stop a lab (volumes persist)          |
-| `rm`     | Destroy a lab and all its data        |
-| `doctor` | Check system health and prerequisites |
+| Command  | Description                                              |
+| -------- | -------------------------------------------------------- |
+| `start`  | Create and start a lab                                   |
+| `list`   | Show all labs and their status                           |
+| `exec`   | Run a command inside a running lab                       |
+| `open`   | Attach VS Code to a running lab                          |
+| `stop`   | Stop a lab (volumes persist)                             |
+| `rm`     | Destroy a lab and all its data                           |
+| `preset` | Save, list, show, and delete reusable lab configurations |
+| `doctor` | Check system health and prerequisites                    |
 
 ### `start` flags
+
+Usage: `claudeup-lab start [preset-name] [flags]`
+
+When a preset name is given as a positional argument, its saved values are used as defaults. Any flags provided on the command line override the preset values. Changed fields are displayed with diff-style `-`/`+` markers before the lab starts.
 
 | Flag                     | Default               | Description                                                                |
 | ------------------------ | --------------------- | -------------------------------------------------------------------------- |
@@ -84,6 +104,8 @@ claudeup-lab rm --lab myproject-experimental
 | `--base-profile <name>`  | None                  | Apply a base profile first, then overlay with `--profile`                  |
 | `--firewall`             | Off                   | Enable container firewall restricting network to allowed services          |
 | `--init-script <path>`   | None                  | Host script to run after devcontainer setup (runs as node, sudo available) |
+| `--env <KEY=VALUE>`      | None                  | Set container environment variable (repeatable)                            |
+| `--env-file <path>`      | None                  | Read container environment variables from file                             |
 
 ### Environment variables
 
@@ -120,6 +142,64 @@ claudeup-lab exec --lab myproject-experimental   # display name
 claudeup-lab exec --lab 976ae3b3                 # partial UUID
 claudeup-lab exec                                # inferred from cwd
 ```
+
+## Presets
+
+Presets are saved lab configurations that you can reuse. Instead of remembering which flags to pass every time you start a lab, save the configuration once and start from it by name.
+
+### Saving a preset
+
+The easiest way to create a preset is from an existing lab:
+
+```bash
+claudeup-lab preset save my-config --from-lab myproject-experimental
+```
+
+This captures the lab's resolved start options -- project, profile, branch, features, environment variables, and all other flags that were used when the lab was created.
+
+You can also create a preset from explicit flags without a running lab:
+
+```bash
+claudeup-lab preset save gpu-lab --project ~/code/ml-project --profile gpu --feature python --env CUDA_VISIBLE_DEVICES=0
+```
+
+### Starting from a preset
+
+Pass the preset name as a positional argument to `start`:
+
+```bash
+claudeup-lab start my-config
+```
+
+Any flag provided on the command line overrides the preset value. Changed fields are displayed with diff-style markers before the lab starts:
+
+```bash
+claudeup-lab start my-config --branch lab/experiment
+# Using preset 'my-config'
+#   project:      /Users/you/code/myproject
+#   profile:      experimental
+# - branch:       lab/experimental
+# + branch:       lab/experiment
+```
+
+Flags that match the preset value produce no diff output.
+
+### Managing presets
+
+```bash
+# List all saved presets
+claudeup-lab preset list
+
+# View details of a specific preset
+claudeup-lab preset show my-config
+
+# Delete a preset
+claudeup-lab preset delete my-config
+```
+
+### Sharing presets
+
+Preset files are human-readable JSON stored in `~/.claudeup-lab/presets/`. Each preset is a single `<name>.json` file that can be copied between machines.
 
 ## How It Works
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,8 @@ cmd/claudeup-lab/       Entry point
 internal/
   commands/             Cobra command handlers
   lab/                  Core domain: Manager, Resolver, WorktreeManager,
-                        ProfileManager, DevcontainerConfig, StateStore
+                        ProfileManager, DevcontainerConfig, StateStore,
+                        PresetStore (preset.go), override merging (override.go)
   docker/               Docker CLI wrapper: Client, ImageManager
 embed/                  Embedded Dockerfile, init scripts, features registry
 scripts/                Install script
@@ -31,6 +32,10 @@ scripts/                Install script
 | DevcontainerConfig | lab     | Renders devcontainer.json with mounts, environment variables, and features                                    |
 | StateStore         | lab     | Reads and writes lab metadata as JSON files                                                                   |
 | Client             | docker  | Container and volume operations via the docker CLI                                                            |
+| Preset             | lab     | Reusable lab configuration with name, timestamps, and start options                                           |
+| PresetStore        | lab     | CRUD for preset JSON files in ~/.claudeup-lab/presets/                                                        |
+| StartConfig        | lab     | Resolved start options tracked on lab Metadata for --from-lab                                                 |
+| Override           | lab     | Single field diff between preset and CLI flag values                                                          |
 | ImageManager       | docker  | Pulls images from GHCR, falls back to building from the embedded Dockerfile                                   |
 
 ## Data Flow
@@ -51,6 +56,20 @@ claudeup-lab start --project ~/myapp --profile experimental
 
 Other commands (list, exec, stop, rm) follow a simpler pattern: resolve the lab, then perform a single operation.
 
+**Preset flow:**
+
+```
+preset save --from-lab <name>
+  -> Resolver finds lab by name -> reads StartConfig from Metadata
+  -> Creates Preset from StartConfig -> PresetStore writes JSON
+
+start <preset-name> [--flag overrides]
+  -> PresetStore loads Preset -> converts to StartOptions
+  -> MergeWithOverrides applies CLI flags over preset defaults
+  -> FormatOverrides renders diff-style summary to stderr
+  -> Proceeds with normal start flow using merged options
+```
+
 ## Storage Layout
 
 ```
@@ -58,6 +77,7 @@ Other commands (list, exec, stop, rm) follow a simpler pattern: resolve the lab,
   state/<uuid>.json                    Lab metadata
   repos/<project>.git                  Bare clone (shared across labs of same project)
   workspaces/<display-name>/           Git worktree per lab
+  presets/<name>.json                  Saved preset configurations
 ```
 
 Each lab also creates Docker volumes scoped by UUID to prevent parallel labs from interfering with each other:
@@ -84,3 +104,9 @@ All lab data lives under `~/.claudeup-lab/`, deliberately separate from `~/.clau
 - **Image pull with build fallback** -- the image manager tries to pull from GHCR first. If the registry is unreachable, it builds locally from the embedded Dockerfile. This keeps the tool usable offline.
 
 - **Fuzzy lab resolution** -- labs can be identified by exact UUID, display name, UUID prefix, project name, profile name, or inferred from the current working directory. The resolver tries each in order, so users rarely need to type a full UUID.
+
+- **Per-lab StartConfig tracking** -- resolved start options are stored on Metadata so any lab (running or stopped) can be a preset source. The StartConfig is deleted automatically when the lab is removed.
+
+- **Explicit Preset struct** -- mirrors StartOptions fields but is a separate type for serialization stability. Conversion functions (`PresetFromStartOptions`, `Preset.ToStartOptions`) bridge the two.
+
+- **Diff-style override display** -- when starting from a preset with overrides, changed values are shown with `-`/`+` markers. Flags that match the preset value produce no diff output.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -244,3 +244,49 @@ claudeup-lab start --base-profile default --profile solo-test
 ```
 
 This applies `default` at user scope, then `solo-test` at project scope, so you get your foundation settings plus just the plugin under test.
+
+## How do I save a lab configuration for reuse?
+
+Use `preset save` with `--from-lab` to capture an existing lab's configuration:
+
+```bash
+claudeup-lab preset save my-config --from-lab myproject-experimental
+```
+
+This reads the lab's tracked start options (project, profile, branch, features, environment variables, and all other flags) and saves them as a named preset. The lab can be running or stopped.
+
+You can also create a preset from explicit flags:
+
+```bash
+claudeup-lab preset save gpu-lab --project ~/code/ml-project --profile gpu --feature python
+```
+
+The two modes are mutually exclusive -- you cannot combine `--from-lab` with other start flags.
+
+## Can I override preset values when starting?
+
+Yes. Pass the preset name as a positional argument to `start`, then add any flags you want to change:
+
+```bash
+claudeup-lab start my-config --branch lab/experiment
+```
+
+The output shows which fields were changed with diff-style markers:
+
+```
+Using preset 'my-config'
+  project:      /Users/you/code/myproject
+  profile:      experimental
+- branch:       lab/experimental
++ branch:       lab/experiment
+```
+
+Unchanged fields are listed without markers. Fields that match the preset value produce no diff output even if the flag was explicitly passed.
+
+## Where are presets stored?
+
+Presets are JSON files in `~/.claudeup-lab/presets/<name>.json`. The format is human-readable and stable. You can share presets between machines by copying the files.
+
+## What happens when I delete a lab that was used to create a preset?
+
+The preset is independent of the lab. Deleting a lab does not affect any presets that were created from it. The preset captured a snapshot of the lab's start options at the time `preset save` was run -- it does not maintain a reference back to the lab.

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -12,6 +12,10 @@ func defaultBaseDir() string {
 	return filepath.Join(os.Getenv("HOME"), ".claudeup-lab")
 }
 
+// baseDirFn returns the base directory for lab data. It defaults to
+// defaultBaseDir and can be replaced in tests to use a temp directory.
+var baseDirFn = defaultBaseDir
+
 func resolveLab(resolver *lab.Resolver, name string) (*lab.Metadata, error) {
 	if name != "" {
 		return resolver.Resolve(name)

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -31,7 +31,7 @@ func newPresetCmd() *cobra.Command {
 // Used to detect mutual exclusivity with --from-lab.
 // SYNC: must match the flags registered in newStartCmd() and newPresetSaveCmd().
 var startFlagNames = []string{
-	"project", "profile", "branch", "feature", "base-profile",
+	"project", "profile", "branch", "name", "feature", "base-profile",
 	"firewall", "init-script", "env", "env-file",
 }
 
@@ -165,6 +165,7 @@ func newPresetSaveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Project directory")
 	cmd.Flags().StringVar(&opts.Profile, "profile", "", "claudeup profile")
 	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Git branch name")
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Display name for the lab")
 	cmd.Flags().StringSliceVar(&features, "feature", nil, "Devcontainer feature (repeatable)")
 	cmd.Flags().StringVar(&opts.BaseProfile, "base-profile", "", "Base profile")
 	cmd.Flags().BoolVar(&opts.Firewall, "firewall", false, "Enable container firewall")
@@ -361,6 +362,20 @@ func newPresetShowCmd() *cobra.Command {
 
 // presetFromStartConfig creates a Preset from a lab's tracked StartConfig.
 func presetFromStartConfig(name string, cfg *lab.StartConfig) *lab.Preset {
+	var features []string
+	if cfg.Features != nil {
+		features = make([]string, len(cfg.Features))
+		copy(features, cfg.Features)
+	}
+
+	var envVars map[string]string
+	if cfg.EnvVars != nil {
+		envVars = make(map[string]string, len(cfg.EnvVars))
+		for k, v := range cfg.EnvVars {
+			envVars[k] = v
+		}
+	}
+
 	return &lab.Preset{
 		Name:        name,
 		CreatedAt:   time.Now().UTC(),
@@ -368,11 +383,11 @@ func presetFromStartConfig(name string, cfg *lab.StartConfig) *lab.Preset {
 		Profile:     cfg.Profile,
 		Branch:      cfg.Branch,
 		LabName:     cfg.LabName,
-		Features:    cfg.Features,
+		Features:    features,
 		BaseProfile: cfg.BaseProfile,
 		Firewall:    cfg.Firewall,
 		InitScript:  cfg.InitScript,
-		EnvVars:     cfg.EnvVars,
+		EnvVars:     envVars,
 		EnvFile:     cfg.EnvFile,
 	}
 }

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+	"github.com/spf13/cobra"
+)
+
+func newPresetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "preset",
+		Short: "Manage reusable lab configurations",
+	}
+
+	cmd.AddCommand(newPresetSaveCmd())
+
+	return cmd
+}
+
+// startFlagNames lists all flag names that correspond to start options.
+// Used to detect mutual exclusivity with --from-lab.
+var startFlagNames = []string{
+	"project", "profile", "branch", "feature", "base-profile",
+	"firewall", "init-script", "env", "env-file",
+}
+
+func newPresetSaveCmd() *cobra.Command {
+	var fromLab string
+	var force bool
+	var opts lab.StartOptions
+	var features []string
+	var envFlags []string
+
+	cmd := &cobra.Command{
+		Use:   "save <name>",
+		Short: "Save a preset from flags or a lab's tracked configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			mgr := lab.NewManager(baseDirFn())
+
+			// Check mutual exclusivity: --from-lab vs start flags
+			fromLabSet := cmd.Flags().Changed("from-lab")
+			anyStartFlagSet := false
+			for _, f := range startFlagNames {
+				if cmd.Flags().Changed(f) {
+					anyStartFlagSet = true
+					break
+				}
+			}
+
+			if fromLabSet && anyStartFlagSet {
+				return fmt.Errorf("--from-lab cannot be combined with other flags")
+			}
+			if !fromLabSet && !anyStartFlagSet {
+				return fmt.Errorf("provide --from-lab or at least one start flag (--project, --profile, etc.)")
+			}
+
+			var preset *lab.Preset
+
+			if fromLabSet {
+				// Build preset from lab's tracked config
+				resolver := lab.NewResolver(mgr.Store())
+				meta, err := resolver.Resolve(fromLab)
+				if err != nil {
+					return fmt.Errorf("lab '%s' not found", fromLab)
+				}
+				if meta.StartConfig == nil {
+					return fmt.Errorf("lab '%s' has no tracked configuration", fromLab)
+				}
+				preset = presetFromStartConfig(name, meta.StartConfig)
+			} else {
+				// Build preset from explicit flags
+				opts.Features = features
+
+				envVars, err := parseEnvFlags(envFlags)
+				if err != nil {
+					return err
+				}
+				opts.EnvVars = envVars
+
+				// Resolve paths to absolute
+				if opts.Project != "" {
+					abs, err := filepath.Abs(opts.Project)
+					if err != nil {
+						return fmt.Errorf("resolve project path: %w", err)
+					}
+					opts.Project = abs
+				}
+
+				resolved, err := resolveInitScript(opts.InitScript)
+				if err != nil {
+					return err
+				}
+				opts.InitScript = resolved
+
+				if opts.EnvFile != "" {
+					abs, err := filepath.Abs(opts.EnvFile)
+					if err != nil {
+						return fmt.Errorf("resolve env-file path: %w", err)
+					}
+					opts.EnvFile = abs
+				}
+
+				preset = lab.PresetFromStartOptions(name, &opts)
+			}
+
+			// Check for existing preset
+			_, err := mgr.Presets().Load(name)
+			if err == nil && !force {
+				if !confirm(fmt.Sprintf("Preset '%s' already exists. Overwrite?", name)) {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			if err := mgr.Presets().Save(preset); err != nil {
+				return err
+			}
+
+			fmt.Printf("Preset saved: %s\n", name)
+			fields := lab.FormatPresetFields(preset)
+			if fields != "" {
+				fmt.Println(fields)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromLab, "from-lab", "", "Capture configuration from a named lab")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing preset without prompting")
+
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Project directory")
+	cmd.Flags().StringVar(&opts.Profile, "profile", "", "claudeup profile")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Git branch name")
+	cmd.Flags().StringSliceVar(&features, "feature", nil, "Devcontainer feature (repeatable)")
+	cmd.Flags().StringVar(&opts.BaseProfile, "base-profile", "", "Base profile")
+	cmd.Flags().BoolVar(&opts.Firewall, "firewall", false, "Enable container firewall")
+	cmd.Flags().StringVar(&opts.InitScript, "init-script", "", "Host script to run after setup")
+	cmd.Flags().StringArrayVar(&envFlags, "env", nil, "Set environment variable as KEY=VALUE (repeatable)")
+	cmd.Flags().StringVar(&opts.EnvFile, "env-file", "", "Read environment variables from file")
+
+	return cmd
+}
+
+// presetFromStartConfig creates a Preset from a lab's tracked StartConfig.
+func presetFromStartConfig(name string, cfg *lab.StartConfig) *lab.Preset {
+	return &lab.Preset{
+		Name:        name,
+		Project:     cfg.Project,
+		Profile:     cfg.Profile,
+		Branch:      cfg.Branch,
+		LabName:     cfg.LabName,
+		Features:    cfg.Features,
+		BaseProfile: cfg.BaseProfile,
+		Firewall:    cfg.Firewall,
+		InitScript:  cfg.InitScript,
+		EnvVars:     cfg.EnvVars,
+		EnvFile:     cfg.EnvFile,
+	}
+}

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -121,12 +121,27 @@ func newPresetSaveCmd() *cobra.Command {
 				preset = lab.PresetFromStartOptions(name, &opts)
 			}
 
-			// Check for existing preset
-			_, err := mgr.Presets().Load(name)
-			if err == nil && !force {
+			// Check for existing preset before saving.
+			_, loadErr := mgr.Presets().Load(name)
+			if loadErr == nil && !force {
+				// Preset exists and is valid -- confirm overwrite.
 				if !confirm(fmt.Sprintf("Preset '%s' already exists. Overwrite?", name)) {
 					fmt.Println("Aborted.")
 					return nil
+				}
+			} else if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
+				// File exists but failed to load. This could be a corrupt file
+				// or a name validation error. Only treat it as corrupt if the
+				// file actually exists on disk.
+				presetPath := filepath.Join(baseDirFn(), "presets", name+".json")
+				if _, statErr := os.Stat(presetPath); statErr == nil {
+					fmt.Fprintf(os.Stderr, "Warning: existing preset '%s' is corrupt: %v\n", name, loadErr)
+					if !force {
+						if !confirm(fmt.Sprintf("Overwrite corrupt preset '%s'?", name)) {
+							fmt.Println("Aborted.")
+							return nil
+						}
+					}
 				}
 			}
 

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/claudeup/claudeup-lab/internal/lab"
 	"github.com/spf13/cobra"
@@ -15,6 +17,9 @@ func newPresetCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newPresetSaveCmd())
+	cmd.AddCommand(newPresetDeleteCmd())
+	cmd.AddCommand(newPresetListCmd())
+	cmd.AddCommand(newPresetShowCmd())
 
 	return cmd
 }
@@ -145,6 +150,184 @@ func newPresetSaveCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.EnvFile, "env-file", "", "Read environment variables from file")
 
 	return cmd
+}
+
+func newPresetDeleteCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <name>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a saved preset",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			mgr := lab.NewManager(baseDirFn())
+
+			if _, err := mgr.Presets().Load(name); err != nil {
+				return fmt.Errorf("preset '%s' not found", name)
+			}
+
+			if !force {
+				if !confirm(fmt.Sprintf("Delete preset '%s'?", name)) {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			if err := mgr.Presets().Delete(name); err != nil {
+				return err
+			}
+
+			fmt.Printf("Deleted preset: %s\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func newPresetListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List saved presets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mgr := lab.NewManager(baseDirFn())
+
+			presets, err := mgr.Presets().List()
+			if err != nil {
+				return err
+			}
+
+			if len(presets) == 0 {
+				fmt.Println("No presets found.")
+				return nil
+			}
+
+			// Calculate dynamic column widths
+			nameW, projW, profW, flagsW := len("NAME"), len("PROJECT"), len("PROFILE"), len("FLAGS")
+			type row struct {
+				name, project, profile, flags string
+			}
+			rows := make([]row, len(presets))
+
+			for i, p := range presets {
+				r := row{
+					name:    p.Name,
+					project: presetProjectColumn(p),
+					profile: presetProfileColumn(p),
+					flags:   presetFlagsColumn(p),
+				}
+				rows[i] = r
+				if len(r.name) > nameW {
+					nameW = len(r.name)
+				}
+				if len(r.project) > projW {
+					projW = len(r.project)
+				}
+				if len(r.profile) > profW {
+					profW = len(r.profile)
+				}
+				if len(r.flags) > flagsW {
+					flagsW = len(r.flags)
+				}
+			}
+
+			fmtStr := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%s\n", nameW, projW, profW)
+			fmt.Printf(fmtStr, "NAME", "PROJECT", "PROFILE", "FLAGS")
+			fmt.Printf(fmtStr, strings.Repeat("-", nameW), strings.Repeat("-", projW), strings.Repeat("-", profW), strings.Repeat("-", flagsW))
+
+			for _, r := range rows {
+				fmt.Printf(fmtStr, r.name, r.project, r.profile, r.flags)
+			}
+
+			return nil
+		},
+	}
+}
+
+func presetProjectColumn(p *lab.Preset) string {
+	if p.Project == "" {
+		return "(none)"
+	}
+	return filepath.Base(p.Project)
+}
+
+func presetProfileColumn(p *lab.Preset) string {
+	if p.Profile == "" {
+		return "(none)"
+	}
+	return p.Profile
+}
+
+// presetFlagsColumn builds a condensed FLAGS string for the list table.
+func presetFlagsColumn(p *lab.Preset) string {
+	var parts []string
+
+	if p.BaseProfile != "" {
+		parts = append(parts, "--base-profile="+p.BaseProfile)
+	}
+	if p.Branch != "" {
+		parts = append(parts, "--branch="+p.Branch)
+	}
+	if len(p.EnvVars) > 0 {
+		keys := make([]string, 0, len(p.EnvVars))
+		for k := range p.EnvVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts = append(parts, "--env="+strings.Join(keys, ","))
+	}
+	if p.EnvFile != "" {
+		parts = append(parts, "--env-file="+filepath.Base(p.EnvFile))
+	}
+	if len(p.Features) > 0 {
+		parts = append(parts, "--feature="+strings.Join(p.Features, ","))
+	}
+	if p.Firewall {
+		parts = append(parts, "--firewall")
+	}
+	if p.InitScript != "" {
+		parts = append(parts, "--init-script="+filepath.Base(p.InitScript))
+	}
+	if p.LabName != "" {
+		parts = append(parts, "--name="+p.LabName)
+	}
+
+	if len(parts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(parts, " ")
+}
+
+func newPresetShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Display details of a saved preset",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			mgr := lab.NewManager(baseDirFn())
+
+			p, err := mgr.Presets().Load(name)
+			if err != nil {
+				return fmt.Errorf("preset '%s' not found", name)
+			}
+
+			fmt.Printf("Preset: %s\n", p.Name)
+			fields := lab.FormatPresetFields(p)
+			if fields != "" {
+				fmt.Println(fields)
+			}
+
+			return nil
+		},
+	}
 }
 
 // presetFromStartConfig creates a Preset from a lab's tracked StartConfig.

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -49,6 +49,10 @@ func newPresetSaveCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
+			if err := lab.ValidatePresetName(name); err != nil {
+				return err
+			}
+
 			mgr := lab.NewManager(baseDirFn())
 
 			// Check mutual exclusivity: --from-lab vs start flags
@@ -130,17 +134,14 @@ func newPresetSaveCmd() *cobra.Command {
 					return nil
 				}
 			} else if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
-				// File exists but failed to load. This could be a corrupt file
-				// or a name validation error. Only treat it as corrupt if the
-				// file actually exists on disk.
-				presetPath := filepath.Join(baseDirFn(), "presets", name+".json")
-				if _, statErr := os.Stat(presetPath); statErr == nil {
-					fmt.Fprintf(os.Stderr, "Warning: existing preset '%s' is corrupt: %v\n", name, loadErr)
-					if !force {
-						if !confirm(fmt.Sprintf("Overwrite corrupt preset '%s'?", name)) {
-							fmt.Println("Aborted.")
-							return nil
-						}
+				// Failed to load an existing preset. This could be a corrupt file
+				// or a name validation error. Warn without probing the filesystem
+				// with the raw name to avoid path traversal.
+				fmt.Fprintf(os.Stderr, "Warning: existing preset '%s' could not be loaded: %v\n", name, loadErr)
+				if !force {
+					if !confirm(fmt.Sprintf("Overwrite preset '%s' despite load error?", name)) {
+						fmt.Println("Aborted.")
+						return nil
 					}
 				}
 			}

--- a/internal/commands/preset.go
+++ b/internal/commands/preset.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/claudeup/claudeup-lab/internal/lab"
 	"github.com/spf13/cobra"
@@ -26,6 +29,7 @@ func newPresetCmd() *cobra.Command {
 
 // startFlagNames lists all flag names that correspond to start options.
 // Used to detect mutual exclusivity with --from-lab.
+// SYNC: must match the flags registered in newStartCmd() and newPresetSaveCmd().
 var startFlagNames = []string{
 	"project", "profile", "branch", "feature", "base-profile",
 	"firewall", "init-script", "env", "env-file",
@@ -71,7 +75,11 @@ func newPresetSaveCmd() *cobra.Command {
 				resolver := lab.NewResolver(mgr.Store())
 				meta, err := resolver.Resolve(fromLab)
 				if err != nil {
-					return fmt.Errorf("lab '%s' not found", fromLab)
+					var notFound *lab.NotFoundError
+					if errors.As(err, &notFound) {
+						return fmt.Errorf("lab '%s' not found", fromLab)
+					}
+					return fmt.Errorf("resolve lab '%s': %w", fromLab, err)
 				}
 				if meta.StartConfig == nil {
 					return fmt.Errorf("lab '%s' has no tracked configuration", fromLab)
@@ -166,7 +174,10 @@ func newPresetDeleteCmd() *cobra.Command {
 			mgr := lab.NewManager(baseDirFn())
 
 			if _, err := mgr.Presets().Load(name); err != nil {
-				return fmt.Errorf("preset '%s' not found", name)
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("preset '%s' not found", name)
+				}
+				return fmt.Errorf("failed to load preset %q: %w", name, err)
 			}
 
 			if !force {
@@ -316,7 +327,10 @@ func newPresetShowCmd() *cobra.Command {
 
 			p, err := mgr.Presets().Load(name)
 			if err != nil {
-				return fmt.Errorf("preset '%s' not found", name)
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("preset '%s' not found", name)
+				}
+				return fmt.Errorf("failed to load preset %q: %w", name, err)
 			}
 
 			fmt.Printf("Preset: %s\n", p.Name)
@@ -334,6 +348,7 @@ func newPresetShowCmd() *cobra.Command {
 func presetFromStartConfig(name string, cfg *lab.StartConfig) *lab.Preset {
 	return &lab.Preset{
 		Name:        name,
+		CreatedAt:   time.Now().UTC(),
 		Project:     cfg.Project,
 		Profile:     cfg.Profile,
 		Branch:      cfg.Branch,

--- a/internal/commands/preset_e2e_test.go
+++ b/internal/commands/preset_e2e_test.go
@@ -1,0 +1,477 @@
+package commands
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+)
+
+// TestE2E_SaveFromFlags_ThenListShowStart exercises the full journey of saving a
+// preset from explicit flags, then listing, showing, and starting from it.
+func TestE2E_SaveFromFlags_ThenListShowStart(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	projDir := t.TempDir()
+
+	// Step 1: Save a preset from explicit flags
+	saveOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "my-config",
+			"--project", projDir,
+			"--profile", "zsh",
+			"--branch", "lab/zsh",
+			"--firewall",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("preset save failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(saveOutput, "Preset saved: my-config") {
+		t.Errorf("save output should contain 'Preset saved: my-config', got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "project:") {
+		t.Errorf("save output should contain 'project:', got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "zsh") {
+		t.Errorf("save output should contain 'zsh', got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "lab/zsh") {
+		t.Errorf("save output should contain 'lab/zsh', got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "firewall:") {
+		t.Errorf("save output should contain 'firewall:', got:\n%s", saveOutput)
+	}
+
+	// Step 2: List presets and verify my-config appears
+	listOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("preset list failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(listOutput, "my-config") {
+		t.Errorf("list output should contain 'my-config', got:\n%s", listOutput)
+	}
+	projBase := filepath.Base(projDir)
+	if !strings.Contains(listOutput, projBase) {
+		t.Errorf("list output should contain project basename %q, got:\n%s", projBase, listOutput)
+	}
+	if !strings.Contains(listOutput, "zsh") {
+		t.Errorf("list output should contain profile 'zsh', got:\n%s", listOutput)
+	}
+	if !strings.Contains(listOutput, "--firewall") {
+		t.Errorf("list FLAGS should contain '--firewall', got:\n%s", listOutput)
+	}
+
+	// Step 3: Show the preset and verify full details
+	showOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "my-config"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("preset show failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(showOutput, "Preset: my-config") {
+		t.Errorf("show output should contain 'Preset: my-config', got:\n%s", showOutput)
+	}
+	if !strings.Contains(showOutput, projDir) {
+		t.Errorf("show output should contain full project path %q, got:\n%s", projDir, showOutput)
+	}
+	if !strings.Contains(showOutput, "zsh") {
+		t.Errorf("show output should contain profile 'zsh', got:\n%s", showOutput)
+	}
+	if !strings.Contains(showOutput, "lab/zsh") {
+		t.Errorf("show output should contain branch 'lab/zsh', got:\n%s", showOutput)
+	}
+	if !strings.Contains(showOutput, "firewall:") && !strings.Contains(showOutput, "true") {
+		t.Errorf("show output should contain firewall=true, got:\n%s", showOutput)
+	}
+
+	// Step 4: Start from the preset (will fail at Docker, but verify preset loading output)
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "my-config"})
+	_ = cmd.Execute()
+
+	startOutput := stderr.String()
+	if !strings.Contains(startOutput, "Using preset 'my-config'") {
+		t.Errorf("start stderr should contain \"Using preset 'my-config'\", got:\n%s", startOutput)
+	}
+	if !strings.Contains(startOutput, projDir) {
+		t.Errorf("start stderr should contain project path %q, got:\n%s", projDir, startOutput)
+	}
+	if !strings.Contains(startOutput, "zsh") {
+		t.Errorf("start stderr should contain profile 'zsh', got:\n%s", startOutput)
+	}
+	if !strings.Contains(startOutput, "lab/zsh") {
+		t.Errorf("start stderr should contain branch 'lab/zsh', got:\n%s", startOutput)
+	}
+}
+
+// TestE2E_SaveFromLab exercises saving a preset from a lab's tracked configuration.
+func TestE2E_SaveFromLab(t *testing.T) {
+	base, mgr := setupPresetTestEnv(t)
+
+	// Set up a lab with StartConfig in its state file
+	meta := &lab.Metadata{
+		ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		DisplayName: "source-lab",
+		Project:     "/tmp/test-project",
+		ProjectName: "test-project",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		StartConfig: &lab.StartConfig{
+			Project:     "/tmp/test-project",
+			Profile:     "zsh",
+			Branch:      "lab/zsh",
+			BaseProfile: "base",
+			Firewall:    true,
+		},
+	}
+	if err := mgr.Store().Save(meta); err != nil {
+		t.Fatalf("failed to save lab state: %v", err)
+	}
+
+	// Save a preset from the lab
+	saveOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "from-lab-test",
+			"--from-lab", "source-lab",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("preset save --from-lab failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(saveOutput, "Preset saved: from-lab-test") {
+		t.Errorf("save output should contain 'Preset saved: from-lab-test', got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "/tmp/test-project") {
+		t.Errorf("save output should contain project path, got:\n%s", saveOutput)
+	}
+	if !strings.Contains(saveOutput, "zsh") {
+		t.Errorf("save output should contain profile 'zsh', got:\n%s", saveOutput)
+	}
+
+	// Verify the preset file exists at the expected location
+	presetPath := filepath.Join(base, "presets", "from-lab-test.json")
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("from-lab-test")
+	if err != nil {
+		t.Fatalf("preset file should exist at %s, load error: %v", presetPath, err)
+	}
+	if p.Project != "/tmp/test-project" {
+		t.Errorf("preset project = %q, want /tmp/test-project", p.Project)
+	}
+	if p.Profile != "zsh" {
+		t.Errorf("preset profile = %q, want zsh", p.Profile)
+	}
+	if p.Branch != "lab/zsh" {
+		t.Errorf("preset branch = %q, want lab/zsh", p.Branch)
+	}
+	if p.BaseProfile != "base" {
+		t.Errorf("preset base-profile = %q, want base", p.BaseProfile)
+	}
+	if !p.Firewall {
+		t.Error("preset firewall = false, want true")
+	}
+}
+
+// TestE2E_StartFromPresetWithOverrides exercises starting from a preset with
+// command-line overrides, verifying the diff-style output.
+func TestE2E_StartFromPresetWithOverrides(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	// Save a preset
+	saveTestPreset(t, base, &lab.Preset{
+		Name:    "override-test",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+		Branch:  "lab/zsh",
+	})
+
+	// Start with a branch override
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "override-test", "--branch", "lab/experiment"})
+	_ = cmd.Execute()
+
+	output := stderr.String()
+
+	// Verify diff markers for the overridden branch
+	if !strings.Contains(output, "- branch:") {
+		t.Errorf("output should contain '- branch:' for old value, got:\n%s", output)
+	}
+	if !strings.Contains(output, "lab/zsh") {
+		t.Errorf("output should contain old branch value 'lab/zsh', got:\n%s", output)
+	}
+	if !strings.Contains(output, "+ branch:") {
+		t.Errorf("output should contain '+ branch:' for new value, got:\n%s", output)
+	}
+	if !strings.Contains(output, "lab/experiment") {
+		t.Errorf("output should contain new branch value 'lab/experiment', got:\n%s", output)
+	}
+
+	// Non-overridden fields should NOT have diff markers
+	if strings.Contains(output, "- project:") || strings.Contains(output, "+ project:") {
+		t.Errorf("project should not have diff markers, got:\n%s", output)
+	}
+	if strings.Contains(output, "- profile:") || strings.Contains(output, "+ profile:") {
+		t.Errorf("profile should not have diff markers, got:\n%s", output)
+	}
+
+	// Non-overridden fields should appear plainly
+	if !strings.Contains(output, "project:") || !strings.Contains(output, "/tmp/proj") {
+		t.Errorf("output should show project field without markers, got:\n%s", output)
+	}
+	if !strings.Contains(output, "profile:") || !strings.Contains(output, "zsh") {
+		t.Errorf("output should show profile field without markers, got:\n%s", output)
+	}
+}
+
+// TestE2E_PresetLifecycle exercises the full lifecycle: save, overwrite with force,
+// verify show reflects new values, delete, verify list is empty, verify show errors.
+func TestE2E_PresetLifecycle(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	projDir := t.TempDir()
+
+	// Step 1: Save a preset
+	captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "lifecycle-test",
+			"--project", projDir,
+			"--profile", "zsh",
+			"--branch", "lab/original",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("initial save failed: %v", err)
+		}
+	})
+
+	// Step 2: Overwrite with --force and different values
+	captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "lifecycle-test",
+			"--project", projDir,
+			"--profile", "fish",
+			"--branch", "lab/updated",
+			"--firewall",
+			"--force",
+		})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("force overwrite failed: %v", err)
+		}
+	})
+
+	// Step 3: Verify show reflects the new values
+	showOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "lifecycle-test"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("show after overwrite failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(showOutput, "fish") {
+		t.Errorf("show should reflect updated profile 'fish', got:\n%s", showOutput)
+	}
+	if !strings.Contains(showOutput, "lab/updated") {
+		t.Errorf("show should reflect updated branch 'lab/updated', got:\n%s", showOutput)
+	}
+	if strings.Contains(showOutput, "lab/original") {
+		t.Errorf("show should NOT contain old branch 'lab/original', got:\n%s", showOutput)
+	}
+	if !strings.Contains(showOutput, "firewall:") {
+		t.Errorf("show should contain firewall field, got:\n%s", showOutput)
+	}
+
+	// Step 4: Delete with --force
+	captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "delete", "lifecycle-test", "--force"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("delete failed: %v", err)
+		}
+	})
+
+	// Step 5: Verify list shows "No presets found."
+	listOutput := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("list after delete failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(listOutput, "No presets found.") {
+		t.Errorf("list after delete should say 'No presets found.', got:\n%s", listOutput)
+	}
+
+	// Step 6: Verify show returns error for deleted preset
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "show", "lifecycle-test"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("show after delete should return error")
+	}
+	if !strings.Contains(err.Error(), "preset 'lifecycle-test' not found") {
+		t.Errorf("error = %q, want 'preset 'lifecycle-test' not found'", err.Error())
+	}
+}
+
+// TestE2E_ErrorScenarios exercises all error paths described in the acceptance criteria.
+func TestE2E_ErrorScenarios(t *testing.T) {
+	t.Run("save_no_flags_no_from_lab", func(t *testing.T) {
+		setupPresetTestEnv(t)
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "save", "empty-test"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error when no flags and no --from-lab")
+		}
+		if !strings.Contains(err.Error(), "provide --from-lab or at least one start flag") {
+			t.Errorf("error = %q, should mention missing flags", err.Error())
+		}
+	})
+
+	t.Run("save_from_lab_with_explicit_flags", func(t *testing.T) {
+		setupPresetTestEnv(t)
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "conflict-test",
+			"--from-lab", "some-lab",
+			"--profile", "zsh",
+		})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error when --from-lab combined with flags")
+		}
+		if !strings.Contains(err.Error(), "--from-lab cannot be combined with other flags") {
+			t.Errorf("error = %q, should mention mutual exclusivity", err.Error())
+		}
+	})
+
+	t.Run("start_nonexistent_preset", func(t *testing.T) {
+		base := t.TempDir()
+		t.Cleanup(setTestBaseDir(base))
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"start", "foo"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for nonexistent preset")
+		}
+		if !strings.Contains(err.Error(), "preset 'foo' not found") {
+			t.Errorf("error = %q, want \"preset 'foo' not found\"", err.Error())
+		}
+	})
+
+	t.Run("show_nonexistent_preset", func(t *testing.T) {
+		setupPresetTestEnv(t)
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "foo"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for nonexistent preset")
+		}
+		if !strings.Contains(err.Error(), "preset 'foo' not found") {
+			t.Errorf("error = %q, want \"preset 'foo' not found\"", err.Error())
+		}
+	})
+
+	t.Run("delete_nonexistent_preset", func(t *testing.T) {
+		setupPresetTestEnv(t)
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "delete", "foo", "--force"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for nonexistent preset")
+		}
+		if !strings.Contains(err.Error(), "preset 'foo' not found") {
+			t.Errorf("error = %q, want \"preset 'foo' not found\"", err.Error())
+		}
+	})
+}
+
+// TestE2E_BackwardCompatibility verifies that pre-feature labs (without StartConfig)
+// load without error, and that preset save --from-lab returns a clear error.
+func TestE2E_BackwardCompatibility(t *testing.T) {
+	t.Run("state_without_start_config_loads", func(t *testing.T) {
+		_, mgr := setupPresetTestEnv(t)
+
+		// Save a lab state without StartConfig (simulating pre-feature lab)
+		meta := &lab.Metadata{
+			ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			DisplayName: "old-lab",
+			Project:     "/tmp/old-project",
+			ProjectName: "old-project",
+			Profile:     "zsh",
+			Branch:      "lab/zsh",
+			// No StartConfig field
+		}
+		if err := mgr.Store().Save(meta); err != nil {
+			t.Fatalf("failed to save lab state: %v", err)
+		}
+
+		// Verify the lab loads without error via the resolver
+		resolver := lab.NewResolver(mgr.Store())
+		loaded, err := resolver.Resolve("old-lab")
+		if err != nil {
+			t.Fatalf("pre-feature lab should load without error: %v", err)
+		}
+		if loaded.StartConfig != nil {
+			t.Error("pre-feature lab should have nil StartConfig")
+		}
+	})
+
+	t.Run("save_from_lab_without_start_config", func(t *testing.T) {
+		_, mgr := setupPresetTestEnv(t)
+
+		// Save a lab state without StartConfig
+		meta := &lab.Metadata{
+			ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			DisplayName: "pre-feature-lab",
+			Project:     "/tmp/old-project",
+			ProjectName: "old-project",
+			Profile:     "zsh",
+			Branch:      "lab/zsh",
+		}
+		if err := mgr.Store().Save(meta); err != nil {
+			t.Fatalf("failed to save lab state: %v", err)
+		}
+
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "from-old",
+			"--from-lab", "pre-feature-lab",
+		})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for lab without StartConfig")
+		}
+		if !strings.Contains(err.Error(), "has no tracked configuration") {
+			t.Errorf("error = %q, should contain 'has no tracked configuration'", err.Error())
+		}
+	})
+}

--- a/internal/commands/preset_test.go
+++ b/internal/commands/preset_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -308,30 +309,21 @@ func TestPresetSave_MissingName(t *testing.T) {
 func TestPresetSave_SuccessOutput(t *testing.T) {
 	setupPresetTestEnv(t)
 
-	// Capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	cmd := NewRootCmd()
-	cmd.SetArgs([]string{
-		"preset", "save", "output-test",
-		"--project", "/tmp/proj",
-		"--profile", "zsh",
-		"--branch", "lab/zsh",
+	var err error
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{
+			"preset", "save", "output-test",
+			"--project", "/tmp/proj",
+			"--profile", "zsh",
+			"--branch", "lab/zsh",
+		})
+		err = cmd.Execute()
 	})
-	err := cmd.Execute()
-
-	w.Close()
-	os.Stdout = old
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	output := string(buf[:n])
 
 	if !strings.Contains(output, "Preset saved: output-test") {
 		t.Errorf("output should contain 'Preset saved: output-test', got:\n%s", output)
@@ -517,24 +509,16 @@ func TestPresetDelete_SuccessOutput(t *testing.T) {
 		t.Fatalf("failed to save preset: %v", err)
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	cmd := NewRootCmd()
-	cmd.SetArgs([]string{"preset", "delete", "output-del", "--force"})
-	err := cmd.Execute()
-
-	w.Close()
-	os.Stdout = old
+	var err error
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "delete", "output-del", "--force"})
+		err = cmd.Execute()
+	})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	output := string(buf[:n])
 
 	if !strings.Contains(output, "Deleted preset: output-del") {
 		t.Errorf("output should contain 'Deleted preset: output-del', got:\n%s", output)
@@ -553,9 +537,8 @@ func captureStdout(t *testing.T, fn func()) string {
 	w.Close()
 	os.Stdout = old
 
-	buf := make([]byte, 8192)
-	n, _ := r.Read(buf)
-	return string(buf[:n])
+	out, _ := io.ReadAll(r)
+	return string(out)
 }
 
 // savePresetDirect saves a preset directly via the store for test setup.
@@ -896,8 +879,8 @@ func TestPresetShow_OmitsEmptyFields(t *testing.T) {
 	if strings.Contains(output, "init-script:") {
 		t.Errorf("should not show empty init-script, got:\n%s", output)
 	}
-	if strings.Contains(output, "env-vars:") {
-		t.Errorf("should not show empty env-vars, got:\n%s", output)
+	if strings.Contains(output, "env:") {
+		t.Errorf("should not show empty env, got:\n%s", output)
 	}
 	if strings.Contains(output, "env-file:") {
 		t.Errorf("should not show empty env-file, got:\n%s", output)

--- a/internal/commands/preset_test.go
+++ b/internal/commands/preset_test.go
@@ -1,0 +1,432 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+)
+
+// setupPresetTestEnv creates a temp base dir with state and presets subdirs,
+// returning the base dir and a Manager rooted there.
+func setupPresetTestEnv(t *testing.T) (string, *lab.Manager) {
+	t.Helper()
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+	mgr := lab.NewManager(base)
+	return base, mgr
+}
+
+func TestPresetSave_FromExplicitFlags(t *testing.T) {
+	base, _ := setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "test-preset",
+		"--project", "/tmp/proj",
+		"--profile", "zsh",
+		"--branch", "lab/zsh",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("test-preset")
+	if err != nil {
+		t.Fatalf("failed to load saved preset: %v", err)
+	}
+	if p.Project != "/tmp/proj" {
+		t.Errorf("project = %q, want /tmp/proj", p.Project)
+	}
+	if p.Profile != "zsh" {
+		t.Errorf("profile = %q, want zsh", p.Profile)
+	}
+	if p.Branch != "lab/zsh" {
+		t.Errorf("branch = %q, want lab/zsh", p.Branch)
+	}
+}
+
+func TestPresetSave_FromLab(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	meta := &lab.Metadata{
+		ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		DisplayName: "mylab",
+		Project:     "/tmp/proj",
+		ProjectName: "proj",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		StartConfig: &lab.StartConfig{
+			Project:     "/tmp/proj",
+			Profile:     "zsh",
+			Branch:      "lab/zsh",
+			BaseProfile: "base",
+			Firewall:    true,
+		},
+	}
+	if err := mgr.Store().Save(meta); err != nil {
+		t.Fatalf("failed to save lab state: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "from-lab-preset",
+		"--from-lab", "mylab",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := mgr.Presets()
+	p, err := store.Load("from-lab-preset")
+	if err != nil {
+		t.Fatalf("failed to load saved preset: %v", err)
+	}
+	if p.Project != "/tmp/proj" {
+		t.Errorf("project = %q, want /tmp/proj", p.Project)
+	}
+	if p.Profile != "zsh" {
+		t.Errorf("profile = %q, want zsh", p.Profile)
+	}
+	if p.Branch != "lab/zsh" {
+		t.Errorf("branch = %q, want lab/zsh", p.Branch)
+	}
+	if p.BaseProfile != "base" {
+		t.Errorf("base-profile = %q, want base", p.BaseProfile)
+	}
+	if !p.Firewall {
+		t.Error("firewall = false, want true")
+	}
+}
+
+func TestPresetSave_FromLabNotFound(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "test-preset",
+		"--from-lab", "nonexistent",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent lab")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q should contain 'not found'", err.Error())
+	}
+}
+
+func TestPresetSave_FromLabNoStartConfig(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	meta := &lab.Metadata{
+		ID:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		DisplayName: "oldlab",
+		Project:     "/tmp/proj",
+		ProjectName: "proj",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+	}
+	if err := mgr.Store().Save(meta); err != nil {
+		t.Fatalf("failed to save lab state: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "test-preset",
+		"--from-lab", "oldlab",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for lab with no StartConfig")
+	}
+	if !strings.Contains(err.Error(), "has no tracked configuration") {
+		t.Errorf("error %q should contain 'has no tracked configuration'", err.Error())
+	}
+}
+
+func TestPresetSave_FromLabCombinedWithFlags(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "test-preset",
+		"--from-lab", "mylab",
+		"--profile", "zsh",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when combining --from-lab with other flags")
+	}
+	if !strings.Contains(err.Error(), "--from-lab cannot be combined with other flags") {
+		t.Errorf("error %q should contain '--from-lab cannot be combined with other flags'", err.Error())
+	}
+}
+
+func TestPresetSave_NoFlagsProvided(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "save", "test-preset"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no flags are provided")
+	}
+	if !strings.Contains(err.Error(), "provide --from-lab or at least one start flag") {
+		t.Errorf("error %q should contain 'provide --from-lab or at least one start flag'", err.Error())
+	}
+}
+
+func TestPresetSave_InvalidName(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "has spaces",
+		"--profile", "zsh",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "invalid characters") {
+		t.Errorf("error %q should contain 'invalid characters'", err.Error())
+	}
+}
+
+func TestPresetSave_PathsResolvedToAbsolute(t *testing.T) {
+	base, _ := setupPresetTestEnv(t)
+
+	projDir := t.TempDir()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "path-test",
+		"--project", projDir,
+		"--profile", "zsh",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("path-test")
+	if err != nil {
+		t.Fatalf("failed to load preset: %v", err)
+	}
+	if !filepath.IsAbs(p.Project) {
+		t.Errorf("project path %q should be absolute", p.Project)
+	}
+}
+
+func TestPresetSave_InitScriptValidation(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "init-test",
+		"--init-script", "/nonexistent/script.sh",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent init script")
+	}
+	if !strings.Contains(err.Error(), "init script not found") {
+		t.Errorf("error %q should contain 'init script not found'", err.Error())
+	}
+}
+
+func TestPresetSave_OverwriteWithForce(t *testing.T) {
+	base, _ := setupPresetTestEnv(t)
+
+	// Save initial preset
+	cmd1 := NewRootCmd()
+	cmd1.SetArgs([]string{
+		"preset", "save", "overwrite-test",
+		"--project", "/tmp/proj1",
+		"--profile", "old-profile",
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first save failed: %v", err)
+	}
+
+	// Overwrite with --force
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{
+		"preset", "save", "overwrite-test",
+		"--project", "/tmp/proj2",
+		"--profile", "new-profile",
+		"--force",
+	})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("force overwrite failed: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("overwrite-test")
+	if err != nil {
+		t.Fatalf("failed to load preset: %v", err)
+	}
+	if p.Project != "/tmp/proj2" {
+		t.Errorf("project = %q, want /tmp/proj2", p.Project)
+	}
+	if p.Profile != "new-profile" {
+		t.Errorf("profile = %q, want new-profile", p.Profile)
+	}
+}
+
+func TestPresetSave_MissingName(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "save"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg(s), received 0") {
+		t.Errorf("error %q should contain cobra's arg count message", err.Error())
+	}
+}
+
+func TestPresetSave_SuccessOutput(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "output-test",
+		"--project", "/tmp/proj",
+		"--profile", "zsh",
+		"--branch", "lab/zsh",
+	})
+	err := cmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "Preset saved: output-test") {
+		t.Errorf("output should contain 'Preset saved: output-test', got:\n%s", output)
+	}
+	if !strings.Contains(output, "project:") {
+		t.Errorf("output should contain 'project:', got:\n%s", output)
+	}
+	if !strings.Contains(output, "/tmp/proj") {
+		t.Errorf("output should contain '/tmp/proj', got:\n%s", output)
+	}
+}
+
+func TestPresetSave_EnvFlags(t *testing.T) {
+	base, _ := setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "env-test",
+		"--profile", "zsh",
+		"--env", "FOO=bar",
+		"--env", "BAZ=qux",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("env-test")
+	if err != nil {
+		t.Fatalf("failed to load preset: %v", err)
+	}
+	if p.EnvVars["FOO"] != "bar" {
+		t.Errorf("env FOO = %q, want bar", p.EnvVars["FOO"])
+	}
+	if p.EnvVars["BAZ"] != "qux" {
+		t.Errorf("env BAZ = %q, want qux", p.EnvVars["BAZ"])
+	}
+}
+
+func TestPresetSave_AllStartFlags(t *testing.T) {
+	base, _ := setupPresetTestEnv(t)
+
+	initScript := filepath.Join(t.TempDir(), "init.sh")
+	if err := os.WriteFile(initScript, []byte("#!/bin/bash\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{
+		"preset", "save", "full-test",
+		"--project", "/tmp/proj",
+		"--profile", "zsh",
+		"--branch", "lab/zsh",
+		"--base-profile", "base",
+		"--firewall",
+		"--init-script", initScript,
+		"--feature", "go:1.23",
+		"--feature", "node:20",
+		"--env", "FOO=bar",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	p, err := store.Load("full-test")
+	if err != nil {
+		t.Fatalf("failed to load preset: %v", err)
+	}
+	if p.Project != "/tmp/proj" {
+		t.Errorf("project = %q", p.Project)
+	}
+	if p.Profile != "zsh" {
+		t.Errorf("profile = %q", p.Profile)
+	}
+	if p.Branch != "lab/zsh" {
+		t.Errorf("branch = %q", p.Branch)
+	}
+	if p.BaseProfile != "base" {
+		t.Errorf("base-profile = %q", p.BaseProfile)
+	}
+	if !p.Firewall {
+		t.Error("firewall = false")
+	}
+	if p.InitScript != initScript {
+		t.Errorf("init-script = %q", p.InitScript)
+	}
+	if len(p.Features) != 2 || p.Features[0] != "go:1.23" || p.Features[1] != "node:20" {
+		t.Errorf("features = %v", p.Features)
+	}
+	if p.EnvVars["FOO"] != "bar" {
+		t.Errorf("env FOO = %q", p.EnvVars["FOO"])
+	}
+}

--- a/internal/commands/preset_test.go
+++ b/internal/commands/preset_test.go
@@ -430,3 +430,476 @@ func TestPresetSave_AllStartFlags(t *testing.T) {
 		t.Errorf("env FOO = %q", p.EnvVars["FOO"])
 	}
 }
+
+func TestPresetDelete_Force(t *testing.T) {
+	base, mgr := setupPresetTestEnv(t)
+
+	// Save a preset first
+	p := &lab.Preset{Name: "del-test", Project: "/tmp/proj", Profile: "zsh"}
+	if err := mgr.Presets().Save(p); err != nil {
+		t.Fatalf("failed to save preset: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "delete", "del-test", "--force"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify preset is gone
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	_, err = store.Load("del-test")
+	if err == nil {
+		t.Fatal("preset should have been deleted")
+	}
+}
+
+func TestPresetDelete_NotFound(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "delete", "nonexistent", "--force"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent preset")
+	}
+	if !strings.Contains(err.Error(), "preset 'nonexistent' not found") {
+		t.Errorf("error %q should contain \"preset 'nonexistent' not found\"", err.Error())
+	}
+}
+
+func TestPresetDelete_AliasRm(t *testing.T) {
+	base, mgr := setupPresetTestEnv(t)
+
+	p := &lab.Preset{Name: "alias-test", Project: "/tmp/proj", Profile: "zsh"}
+	if err := mgr.Presets().Save(p); err != nil {
+		t.Fatalf("failed to save preset: %v", err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "rm", "alias-test", "--force"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	_, err = store.Load("alias-test")
+	if err == nil {
+		t.Fatal("preset should have been deleted via rm alias")
+	}
+}
+
+func TestPresetDelete_TooManyArgs(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "delete", "foo", "bar"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for too many args")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg(s), received 2") {
+		t.Errorf("error %q should contain cobra's arg count message", err.Error())
+	}
+}
+
+func TestPresetDelete_SuccessOutput(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	p := &lab.Preset{Name: "output-del", Project: "/tmp/proj", Profile: "zsh"}
+	if err := mgr.Presets().Save(p); err != nil {
+		t.Fatalf("failed to save preset: %v", err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "delete", "output-del", "--force"})
+	err := cmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "Deleted preset: output-del") {
+		t.Errorf("output should contain 'Deleted preset: output-del', got:\n%s", output)
+	}
+}
+
+// captureStdout runs fn while capturing stdout, returning the captured output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 8192)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+// savePresetDirect saves a preset directly via the store for test setup.
+func savePresetDirect(t *testing.T, mgr *lab.Manager, p *lab.Preset) {
+	t.Helper()
+	if err := mgr.Presets().Save(p); err != nil {
+		t.Fatalf("save preset %q: %v", p.Name, err)
+	}
+}
+
+func TestPresetList_WithPresets(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:        "my-gstack",
+		Project:     "/Users/mark/code/gstack",
+		Profile:     "zsh",
+		Firewall:    true,
+		BaseProfile: "base",
+	})
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:    "quick-test",
+		Project: "/Users/mark/code/myapp",
+		Profile: "default",
+		EnvFile: "/Users/mark/code/myapp/lab.env",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Check header
+	if !strings.Contains(output, "NAME") || !strings.Contains(output, "PROJECT") ||
+		!strings.Contains(output, "PROFILE") || !strings.Contains(output, "FLAGS") {
+		t.Errorf("missing header columns in output:\n%s", output)
+	}
+	// Check separator
+	if !strings.Contains(output, "----") {
+		t.Errorf("missing separator line in output:\n%s", output)
+	}
+	// Check preset rows
+	if !strings.Contains(output, "my-gstack") || !strings.Contains(output, "gstack") || !strings.Contains(output, "zsh") {
+		t.Errorf("missing my-gstack row in output:\n%s", output)
+	}
+	if !strings.Contains(output, "quick-test") || !strings.Contains(output, "myapp") {
+		t.Errorf("missing quick-test row in output:\n%s", output)
+	}
+}
+
+func TestPresetList_NoPresets(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	expected := "No presets found."
+	if !strings.Contains(output, expected) {
+		t.Errorf("output = %q, want %q", output, expected)
+	}
+}
+
+func TestPresetList_Alias(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "ls"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "No presets found.") {
+		t.Errorf("alias 'ls' should work, got output:\n%s", output)
+	}
+}
+
+func TestPresetList_FlagsBooleanFlag(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:     "fw-test",
+		Project:  "/tmp/proj",
+		Profile:  "zsh",
+		Firewall: true,
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "--firewall") {
+		t.Errorf("FLAGS should contain --firewall, got:\n%s", output)
+	}
+}
+
+func TestPresetList_FlagsStringPathFlag(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:       "script-test",
+		Project:    "/tmp/proj",
+		Profile:    "zsh",
+		InitScript: "/Users/mark/scripts/setup.sh",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "--init-script=setup.sh") {
+		t.Errorf("FLAGS should contain --init-script=setup.sh (basename), got:\n%s", output)
+	}
+}
+
+func TestPresetList_FlagsEnvKeysOnly(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:    "env-list-test",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+		EnvVars: map[string]string{"API_KEY": "secret", "DEBUG": "true"},
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "--env=API_KEY,DEBUG") {
+		t.Errorf("FLAGS should contain --env=API_KEY,DEBUG (sorted keys only), got:\n%s", output)
+	}
+	// Must NOT contain the secret value
+	if strings.Contains(output, "secret") {
+		t.Errorf("FLAGS must not contain env values, got:\n%s", output)
+	}
+}
+
+func TestPresetList_FlagsNone(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:    "bare",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// The FLAGS column should show (none)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "bare") {
+			if !strings.Contains(line, "(none)") {
+				t.Errorf("FLAGS for bare preset should be (none), got line:\n%s", line)
+			}
+			break
+		}
+	}
+}
+
+func TestPresetList_ProfileNone(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:    "no-profile",
+		Project: "/tmp/proj",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "list"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "no-profile") {
+			if !strings.Contains(line, "(none)") {
+				t.Errorf("PROFILE for no-profile preset should be (none), got line:\n%s", line)
+			}
+			break
+		}
+	}
+}
+
+func TestPresetShow_FullDetails(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:        "my-gstack",
+		Project:     "/Users/mark/code/gstack",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		BaseProfile: "base",
+		Features:    []string{"go:1.23", "node:20"},
+		Firewall:    true,
+		InitScript:  "/Users/mark/scripts/setup.sh",
+		EnvVars:     map[string]string{"API_KEY": "sk-1234abcd", "DEBUG": "true"},
+		EnvFile:     "/Users/mark/code/gstack/lab.env",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "my-gstack"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Header
+	if !strings.Contains(output, "Preset: my-gstack") {
+		t.Errorf("missing 'Preset: my-gstack' header, got:\n%s", output)
+	}
+	// Full paths
+	if !strings.Contains(output, "/Users/mark/code/gstack") {
+		t.Errorf("missing full project path, got:\n%s", output)
+	}
+	if !strings.Contains(output, "/Users/mark/scripts/setup.sh") {
+		t.Errorf("missing full init-script path, got:\n%s", output)
+	}
+	// Env values shown (not hidden)
+	if !strings.Contains(output, "API_KEY=sk-1234abcd") {
+		t.Errorf("missing env var value, got:\n%s", output)
+	}
+	// Profile
+	if !strings.Contains(output, "zsh") {
+		t.Errorf("missing profile, got:\n%s", output)
+	}
+	// Firewall
+	if !strings.Contains(output, "true") {
+		t.Errorf("missing firewall=true, got:\n%s", output)
+	}
+}
+
+func TestPresetShow_RepeatedValues(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:     "multi-test",
+		Project:  "/tmp/proj",
+		Profile:  "zsh",
+		Features: []string{"go:1.23", "node:20"},
+		EnvVars:  map[string]string{"A": "1", "B": "2"},
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "multi-test"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// Each feature should get its own line
+	if strings.Count(output, "go:1.23") < 1 {
+		t.Errorf("missing feature go:1.23, got:\n%s", output)
+	}
+	if strings.Count(output, "node:20") < 1 {
+		t.Errorf("missing feature node:20, got:\n%s", output)
+	}
+	// Each env var on its own line
+	if strings.Count(output, "A=1") < 1 {
+		t.Errorf("missing env A=1, got:\n%s", output)
+	}
+	if strings.Count(output, "B=2") < 1 {
+		t.Errorf("missing env B=2, got:\n%s", output)
+	}
+}
+
+func TestPresetShow_Nonexistent(t *testing.T) {
+	setupPresetTestEnv(t)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"preset", "show", "nonexistent"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent preset")
+	}
+	if !strings.Contains(err.Error(), "preset 'nonexistent' not found") {
+		t.Errorf("error = %q, want 'preset 'nonexistent' not found'", err.Error())
+	}
+}
+
+func TestPresetShow_OmitsEmptyFields(t *testing.T) {
+	_, mgr := setupPresetTestEnv(t)
+
+	savePresetDirect(t, mgr, &lab.Preset{
+		Name:    "minimal",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+	})
+
+	output := captureStdout(t, func() {
+		cmd := NewRootCmd()
+		cmd.SetArgs([]string{"preset", "show", "minimal"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(output, "branch:") {
+		t.Errorf("should not show empty branch, got:\n%s", output)
+	}
+	if strings.Contains(output, "firewall:") {
+		t.Errorf("should not show false firewall, got:\n%s", output)
+	}
+	if strings.Contains(output, "init-script:") {
+		t.Errorf("should not show empty init-script, got:\n%s", output)
+	}
+	if strings.Contains(output, "env-vars:") {
+		t.Errorf("should not show empty env-vars, got:\n%s", output)
+	}
+	if strings.Contains(output, "env-file:") {
+		t.Errorf("should not show empty env-file, got:\n%s", output)
+	}
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -33,6 +33,7 @@ without affecting your host setup.`,
 	cmd.AddCommand(newStopCmd())
 	cmd.AddCommand(newRmCmd())
 	cmd.AddCommand(newDoctorCmd())
+	cmd.AddCommand(newPresetCmd())
 
 	return cmd
 }

--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/claudeup/claudeup-lab/internal/lab"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func newStartCmd() *cobra.Command {
@@ -17,16 +18,10 @@ func newStartCmd() *cobra.Command {
 	var envFlags []string
 
 	cmd := &cobra.Command{
-		Use:   "start",
+		Use:   "start [preset-name]",
 		Short: "Create and start a lab",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Project == "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("get working directory: %w", err)
-				}
-				opts.Project = cwd
-			}
 			opts.Features = features
 
 			// Parse --env KEY=VALUE flags into map
@@ -42,9 +37,42 @@ func newStartCmd() *cobra.Command {
 			}
 			opts.InitScript = resolved
 
-			mgr := lab.NewManager(defaultBaseDir())
+			mgr := lab.NewManager(baseDirFn())
 
-			meta, err := mgr.Start(&opts)
+			// Determine the final start options, handling preset if specified.
+			finalOpts := &opts
+			if len(args) > 0 {
+				presetName := args[0]
+				preset, loadErr := mgr.Presets().Load(presetName)
+				if loadErr != nil {
+					return fmt.Errorf("preset '%s' not found", presetName)
+				}
+
+				baseOpts := preset.ToStartOptions()
+
+				// Detect which flags were explicitly set on the command line.
+				changed := make(map[string]bool)
+				cmd.Flags().Visit(func(f *pflag.Flag) {
+					changed[f.Name] = true
+				})
+
+				merged, overrides := lab.MergeWithOverrides(baseOpts, &opts, changed)
+				finalOpts = merged
+
+				// Print preset summary to stderr.
+				fmt.Fprint(cmd.ErrOrStderr(), lab.FormatOverrides(preset, overrides))
+			}
+
+			// Apply cwd default for project only if still empty after preset merge.
+			if finalOpts.Project == "" {
+				cwd, cwdErr := os.Getwd()
+				if cwdErr != nil {
+					return fmt.Errorf("get working directory: %w", cwdErr)
+				}
+				finalOpts.Project = cwd
+			}
+
+			meta, err := mgr.Start(finalOpts)
 			if err != nil && meta == nil {
 				return err
 			}

--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -45,7 +45,10 @@ func newStartCmd() *cobra.Command {
 				presetName := args[0]
 				preset, loadErr := mgr.Presets().Load(presetName)
 				if loadErr != nil {
-					return fmt.Errorf("preset '%s' not found", presetName)
+					if errors.Is(loadErr, os.ErrNotExist) {
+						return fmt.Errorf("preset '%s' not found", presetName)
+					}
+					return fmt.Errorf("failed to load preset %q: %w", presetName, loadErr)
 				}
 
 				baseOpts := preset.ToStartOptions()

--- a/internal/commands/start_preset_test.go
+++ b/internal/commands/start_preset_test.go
@@ -1,0 +1,265 @@
+package commands
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+	"github.com/spf13/cobra"
+)
+
+// saveTestPreset creates a preset in the given base directory's preset store.
+func saveTestPreset(t *testing.T, base string, p *lab.Preset) {
+	t.Helper()
+	store := lab.NewPresetStore(filepath.Join(base, "presets"))
+	if err := store.Save(p); err != nil {
+		t.Fatalf("save test preset: %v", err)
+	}
+}
+
+func TestStartWithPreset_NotFound(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"start", "nonexistent-preset"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent preset")
+	}
+	if !strings.Contains(err.Error(), "preset 'nonexistent-preset' not found") {
+		t.Errorf("error %q should contain \"preset 'nonexistent-preset' not found\"", err.Error())
+	}
+}
+
+func TestStartWithPreset_LoadsPresetAndPrintsSummary(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	saveTestPreset(t, base, &lab.Preset{
+		Name:        "my-gstack",
+		Project:     "/tmp/gstack",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		BaseProfile: "base",
+		Firewall:    true,
+	})
+
+	// Capture stderr
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "my-gstack"})
+
+	// Will fail at mgr.Start() (no Docker), but stderr should have preset info
+	_ = cmd.Execute()
+
+	output := stderr.String()
+	if !strings.Contains(output, "Using preset 'my-gstack'") {
+		t.Errorf("stderr should contain \"Using preset 'my-gstack'\", got:\n%s", output)
+	}
+	if !strings.Contains(output, "project:") || !strings.Contains(output, "/tmp/gstack") {
+		t.Errorf("stderr should contain project field, got:\n%s", output)
+	}
+	if !strings.Contains(output, "profile:") || !strings.Contains(output, "zsh") {
+		t.Errorf("stderr should contain profile field, got:\n%s", output)
+	}
+	if !strings.Contains(output, "branch:") || !strings.Contains(output, "lab/zsh") {
+		t.Errorf("stderr should contain branch field, got:\n%s", output)
+	}
+	if !strings.Contains(output, "base-profile:") || !strings.Contains(output, "base") {
+		t.Errorf("stderr should contain base-profile field, got:\n%s", output)
+	}
+	if !strings.Contains(output, "firewall:") || !strings.Contains(output, "true") {
+		t.Errorf("stderr should contain firewall field, got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_OverrideBranchShowsDiff(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	saveTestPreset(t, base, &lab.Preset{
+		Name:    "my-gstack",
+		Project: "/tmp/gstack",
+		Profile: "zsh",
+		Branch:  "lab/zsh",
+	})
+
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "my-gstack", "--branch", "lab/experiment"})
+
+	_ = cmd.Execute()
+
+	output := stderr.String()
+	if !strings.Contains(output, "Using preset 'my-gstack'") {
+		t.Errorf("stderr should contain preset header, got:\n%s", output)
+	}
+	// Override diff markers
+	if !strings.Contains(output, "- branch:") {
+		t.Errorf("stderr should contain '- branch:' for removed value, got:\n%s", output)
+	}
+	if !strings.Contains(output, "lab/zsh") {
+		t.Errorf("stderr should contain old branch value 'lab/zsh', got:\n%s", output)
+	}
+	if !strings.Contains(output, "+ branch:") {
+		t.Errorf("stderr should contain '+ branch:' for new value, got:\n%s", output)
+	}
+	if !strings.Contains(output, "lab/experiment") {
+		t.Errorf("stderr should contain new branch value 'lab/experiment', got:\n%s", output)
+	}
+	// Non-overridden fields should NOT have diff markers
+	if strings.Contains(output, "- project:") || strings.Contains(output, "+ project:") {
+		t.Errorf("project should not have diff markers, got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_NoOverridesShowsPlainFields(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	saveTestPreset(t, base, &lab.Preset{
+		Name:    "simple",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+	})
+
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "simple"})
+
+	_ = cmd.Execute()
+
+	output := stderr.String()
+	if !strings.Contains(output, "Using preset 'simple'") {
+		t.Errorf("stderr should contain preset header, got:\n%s", output)
+	}
+	// No diff markers when there are no overrides
+	if strings.Contains(output, "- ") || strings.Contains(output, "+ ") {
+		t.Errorf("no diff markers expected without overrides, got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_ProjectFromPresetNotCwd(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	saveTestPreset(t, base, &lab.Preset{
+		Name:    "proj-test",
+		Project: "/tmp/specific-project",
+		Profile: "zsh",
+	})
+
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "proj-test"})
+
+	// The command will fail at mgr.Start, but the error should reference
+	// the preset's project, not cwd.
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error (no Docker)")
+	}
+
+	// Check stderr has the preset's project, not cwd
+	output := stderr.String()
+	if !strings.Contains(output, "/tmp/specific-project") {
+		t.Errorf("stderr should show preset project '/tmp/specific-project', got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_UsageLineShowsOptionalPresetArg(t *testing.T) {
+	cmd := NewRootCmd()
+
+	// Find the start subcommand
+	var startCmd *cobra.Command
+	for _, c := range cmd.Commands() {
+		if c.Name() == "start" {
+			startCmd = c
+			break
+		}
+	}
+	if startCmd == nil {
+		t.Fatal("start command not found")
+	}
+
+	if !strings.Contains(startCmd.Use, "[preset-name]") {
+		t.Errorf("start command Use should contain '[preset-name]', got %q", startCmd.Use)
+	}
+}
+
+func TestStartWithoutPreset_NoChangeToExistingBehavior(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"start", "--project", "/tmp/proj", "--profile", "zsh"})
+
+	// Will fail at mgr.Start (no Docker), but should NOT print preset info
+	_ = cmd.Execute()
+
+	output := stderr.String()
+	if strings.Contains(output, "Using preset") {
+		t.Errorf("without preset arg, should not print 'Using preset', got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_MultipleOverrides(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	saveTestPreset(t, base, &lab.Preset{
+		Name:    "multi",
+		Project: "/tmp/proj",
+		Profile: "zsh",
+		Branch:  "lab/zsh",
+		EnvVars: map[string]string{"API_KEY": "sk-1234"},
+	})
+
+	var stderr bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"start", "multi",
+		"--branch", "lab/experiment",
+		"--env", "VERBOSE=1",
+	})
+
+	_ = cmd.Execute()
+
+	output := stderr.String()
+	// Branch should be overridden
+	if !strings.Contains(output, "- branch:") || !strings.Contains(output, "+ branch:") {
+		t.Errorf("branch should have diff markers, got:\n%s", output)
+	}
+	// Env should be overridden (preset env replaced by flag env)
+	if !strings.Contains(output, "- env:") || !strings.Contains(output, "+ env:") {
+		t.Errorf("env should have diff markers, got:\n%s", output)
+	}
+	// Project should not be overridden
+	if strings.Contains(output, "- project:") || strings.Contains(output, "+ project:") {
+		t.Errorf("project should not have diff markers, got:\n%s", output)
+	}
+}
+
+func TestStartWithPreset_TooManyPositionalArgs(t *testing.T) {
+	base := t.TempDir()
+	t.Cleanup(setTestBaseDir(base))
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"start", "preset1", "preset2"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for too many args")
+	}
+}

--- a/internal/commands/test_helpers_test.go
+++ b/internal/commands/test_helpers_test.go
@@ -1,0 +1,8 @@
+package commands
+
+// setTestBaseDir overrides baseDirFn for tests and returns a cleanup function.
+func setTestBaseDir(dir string) func() {
+	orig := baseDirFn
+	baseDirFn = func() string { return dir }
+	return func() { baseDirFn = orig }
+}

--- a/internal/lab/manager.go
+++ b/internal/lab/manager.go
@@ -211,30 +211,16 @@ func (m *Manager) Start(opts *StartOptions) (*Metadata, error) {
 // remaining fields from opts. The resolved params are passed explicitly
 // because opts may still hold raw user input.
 func StartConfigFromResolved(project, profile, branch string, opts *StartOptions) *StartConfig {
-	var featuresCopy []string
-	if opts.Features != nil {
-		featuresCopy = make([]string, len(opts.Features))
-		copy(featuresCopy, opts.Features)
-	}
-
-	var envVarsCopy map[string]string
-	if opts.EnvVars != nil {
-		envVarsCopy = make(map[string]string, len(opts.EnvVars))
-		for k, v := range opts.EnvVars {
-			envVarsCopy[k] = v
-		}
-	}
-
 	return &StartConfig{
 		Project:     project,
 		Profile:     profile,
 		Branch:      branch,
 		LabName:     opts.Name,
-		Features:    featuresCopy,
+		Features:    copySlice(opts.Features),
 		BaseProfile: opts.BaseProfile,
 		Firewall:    opts.Firewall,
 		InitScript:  opts.InitScript,
-		EnvVars:     envVarsCopy,
+		EnvVars:     copyMap(opts.EnvVars),
 		EnvFile:     opts.EnvFile,
 	}
 }

--- a/internal/lab/manager.go
+++ b/internal/lab/manager.go
@@ -18,6 +18,7 @@ import (
 type Manager struct {
 	baseDir   string
 	store     *StateStore
+	presets   *PresetStore
 	worktrees *WorktreeManager
 	profiles  *ProfileManager
 	docker    *docker.Client
@@ -28,6 +29,7 @@ func NewManager(baseDir string) *Manager {
 	return &Manager{
 		baseDir:   baseDir,
 		store:     NewStateStore(filepath.Join(baseDir, "state")),
+		presets:   NewPresetStore(filepath.Join(baseDir, "presets")),
 		worktrees: NewWorktreeManager(filepath.Join(baseDir, "repos")),
 		profiles:  NewProfileManager(filepath.Join(ClaudeupHome(), "profiles")),
 		docker:    docker.NewClient(),
@@ -36,6 +38,7 @@ func NewManager(baseDir string) *Manager {
 }
 
 func (m *Manager) Store() *StateStore          { return m.store }
+func (m *Manager) Presets() *PresetStore       { return m.presets }
 func (m *Manager) Docker() *docker.Client      { return m.docker }
 func (m *Manager) Worktrees() *WorktreeManager { return m.worktrees }
 

--- a/internal/lab/manager.go
+++ b/internal/lab/manager.go
@@ -194,12 +194,32 @@ func (m *Manager) Start(opts *StartOptions) (*Metadata, error) {
 		Branch:      branch,
 		Created:     time.Now().UTC(),
 		Snapshot:    snapshotName,
+		StartConfig: StartConfigFromResolved(projectPath, profile, branch, opts),
 	}
 	if err := m.store.Save(meta); err != nil {
 		return nil, fmt.Errorf("save metadata: %w", err)
 	}
 
 	return meta, postCreateErr
+}
+
+// StartConfigFromResolved builds a StartConfig from the resolved local
+// variables in Manager.Start (project, profile, branch) and copies the
+// remaining fields from opts. The resolved params are passed explicitly
+// because opts may still hold raw user input.
+func StartConfigFromResolved(project, profile, branch string, opts *StartOptions) *StartConfig {
+	return &StartConfig{
+		Project:     project,
+		Profile:     profile,
+		Branch:      branch,
+		LabName:     opts.Name,
+		Features:    opts.Features,
+		BaseProfile: opts.BaseProfile,
+		Firewall:    opts.Firewall,
+		InitScript:  opts.InitScript,
+		EnvVars:     opts.EnvVars,
+		EnvFile:     opts.EnvFile,
+	}
 }
 
 // LabStatus returns the running status of a lab.

--- a/internal/lab/manager.go
+++ b/internal/lab/manager.go
@@ -211,16 +211,30 @@ func (m *Manager) Start(opts *StartOptions) (*Metadata, error) {
 // remaining fields from opts. The resolved params are passed explicitly
 // because opts may still hold raw user input.
 func StartConfigFromResolved(project, profile, branch string, opts *StartOptions) *StartConfig {
+	var featuresCopy []string
+	if opts.Features != nil {
+		featuresCopy = make([]string, len(opts.Features))
+		copy(featuresCopy, opts.Features)
+	}
+
+	var envVarsCopy map[string]string
+	if opts.EnvVars != nil {
+		envVarsCopy = make(map[string]string, len(opts.EnvVars))
+		for k, v := range opts.EnvVars {
+			envVarsCopy[k] = v
+		}
+	}
+
 	return &StartConfig{
 		Project:     project,
 		Profile:     profile,
 		Branch:      branch,
 		LabName:     opts.Name,
-		Features:    opts.Features,
+		Features:    featuresCopy,
 		BaseProfile: opts.BaseProfile,
 		Firewall:    opts.Firewall,
 		InitScript:  opts.InitScript,
-		EnvVars:     opts.EnvVars,
+		EnvVars:     envVarsCopy,
 		EnvFile:     opts.EnvFile,
 	}
 }

--- a/internal/lab/override.go
+++ b/internal/lab/override.go
@@ -1,0 +1,234 @@
+package lab
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Override records a single field that was changed from its preset value.
+type Override struct {
+	Field    string // flag name, e.g. "branch"
+	OldValue string // value from preset (formatted for display)
+	NewValue string // value from CLI flag (formatted for display)
+}
+
+// MergeWithOverrides merges CLI flag values into a base StartOptions from a preset.
+// Only fields whose flag names appear in the changed map are replaced. It returns
+// the merged options and a list of overrides describing what changed.
+func MergeWithOverrides(base *StartOptions, flags *StartOptions, changed map[string]bool) (*StartOptions, []Override) {
+	merged := copyStartOptions(base)
+	var overrides []Override
+
+	type fieldDef struct {
+		flag string
+		get  func(*StartOptions) string
+		set  func(*StartOptions, *StartOptions)
+	}
+
+	stringFields := []fieldDef{
+		{"project", func(o *StartOptions) string { return o.Project }, func(m, f *StartOptions) { m.Project = f.Project }},
+		{"profile", func(o *StartOptions) string { return o.Profile }, func(m, f *StartOptions) { m.Profile = f.Profile }},
+		{"branch", func(o *StartOptions) string { return o.Branch }, func(m, f *StartOptions) { m.Branch = f.Branch }},
+		{"name", func(o *StartOptions) string { return o.Name }, func(m, f *StartOptions) { m.Name = f.Name }},
+		{"base-profile", func(o *StartOptions) string { return o.BaseProfile }, func(m, f *StartOptions) { m.BaseProfile = f.BaseProfile }},
+		{"init-script", func(o *StartOptions) string { return o.InitScript }, func(m, f *StartOptions) { m.InitScript = f.InitScript }},
+		{"env-file", func(o *StartOptions) string { return o.EnvFile }, func(m, f *StartOptions) { m.EnvFile = f.EnvFile }},
+	}
+
+	for _, f := range stringFields {
+		if !changed[f.flag] {
+			continue
+		}
+		oldVal := f.get(base)
+		newVal := f.get(flags)
+		f.set(merged, flags)
+		overrides = append(overrides, Override{
+			Field:    f.flag,
+			OldValue: oldVal,
+			NewValue: newVal,
+		})
+	}
+
+	// Bool: firewall
+	if changed["firewall"] {
+		overrides = append(overrides, Override{
+			Field:    "firewall",
+			OldValue: fmt.Sprintf("%t", base.Firewall),
+			NewValue: fmt.Sprintf("%t", flags.Firewall),
+		})
+		merged.Firewall = flags.Firewall
+	}
+
+	// Slice: feature -> Features
+	if changed["feature"] {
+		overrides = append(overrides, Override{
+			Field:    "feature",
+			OldValue: formatSlice(base.Features),
+			NewValue: formatSlice(flags.Features),
+		})
+		merged.Features = copySlice(flags.Features)
+	}
+
+	// Map: env -> EnvVars
+	if changed["env"] {
+		overrides = append(overrides, Override{
+			Field:    "env",
+			OldValue: formatEnvMap(base.EnvVars),
+			NewValue: formatEnvMap(flags.EnvVars),
+		})
+		merged.EnvVars = copyMap(flags.EnvVars)
+	}
+
+	return merged, overrides
+}
+
+// FormatOverrides renders a preset summary with diff markers for overridden fields.
+func FormatOverrides(preset *Preset, overrides []Override) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Using preset '%s'", preset.Name))
+
+	overrideMap := make(map[string]*Override)
+	for i := range overrides {
+		overrideMap[overrides[i].Field] = &overrides[i]
+	}
+
+	type fieldEntry struct {
+		flag  string
+		value string
+	}
+
+	// Collect fields from the preset in display order.
+	var fields []fieldEntry
+	addField := func(flag, value string) {
+		fields = append(fields, fieldEntry{flag: flag, value: value})
+	}
+
+	if preset.Project != "" {
+		addField("project", preset.Project)
+	}
+	if preset.Profile != "" {
+		addField("profile", preset.Profile)
+	}
+	if preset.Branch != "" {
+		addField("branch", preset.Branch)
+	}
+	if preset.LabName != "" {
+		addField("name", preset.LabName)
+	}
+	if preset.BaseProfile != "" {
+		addField("base-profile", preset.BaseProfile)
+	}
+	if preset.Firewall {
+		addField("firewall", "true")
+	}
+	if preset.InitScript != "" {
+		addField("init-script", preset.InitScript)
+	}
+	if len(preset.Features) > 0 {
+		addField("feature", formatSlice(preset.Features))
+	}
+	if len(preset.EnvVars) > 0 {
+		addField("env", formatEnvMap(preset.EnvVars))
+	}
+	if preset.EnvFile != "" {
+		addField("env-file", preset.EnvFile)
+	}
+
+	// Track which overrides we've rendered (some add fields not in the preset).
+	rendered := make(map[string]bool)
+
+	for _, f := range fields {
+		o, hasOverride := overrideMap[f.flag]
+		if hasOverride {
+			rendered[f.flag] = true
+			if isDisplayableValue(f.flag, o.OldValue) {
+				lines = append(lines, formatLine("-", f.flag, o.OldValue))
+			}
+			if isDisplayableValue(f.flag, o.NewValue) {
+				lines = append(lines, formatLine("+", f.flag, o.NewValue))
+			}
+		} else {
+			lines = append(lines, formatLine(" ", f.flag, f.value))
+		}
+	}
+
+	// Render overrides for fields that were not in the preset (added fields).
+	for _, o := range overrides {
+		if rendered[o.Field] {
+			continue
+		}
+		if isDisplayableValue(o.Field, o.OldValue) {
+			lines = append(lines, formatLine("-", o.Field, o.OldValue))
+		}
+		if isDisplayableValue(o.Field, o.NewValue) {
+			lines = append(lines, formatLine("+", o.Field, o.NewValue))
+		}
+	}
+
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// isDisplayableValue returns true if value is non-zero for the given field.
+// For bool fields, "false" is the zero value.
+func isDisplayableValue(flag, value string) bool {
+	if value == "" {
+		return false
+	}
+	if flag == "firewall" && value == "false" {
+		return false
+	}
+	return true
+}
+
+func formatLine(prefix, flag, value string) string {
+	return fmt.Sprintf("%s %-14s%s", prefix, flag+":", value)
+}
+
+func formatSlice(s []string) string {
+	return strings.Join(s, ",")
+}
+
+func formatEnvMap(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(m))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+m[k])
+	}
+	return strings.Join(pairs, ",")
+}
+
+func copyStartOptions(src *StartOptions) *StartOptions {
+	dst := *src
+	dst.Features = copySlice(src.Features)
+	dst.EnvVars = copyMap(src.EnvVars)
+	return &dst
+}
+
+func copySlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}
+
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	c := make(map[string]string, len(m))
+	for k, v := range m {
+		c[k] = v
+	}
+	return c
+}

--- a/internal/lab/override.go
+++ b/internal/lab/override.go
@@ -43,41 +43,53 @@ func MergeWithOverrides(base *StartOptions, flags *StartOptions, changed map[str
 		oldVal := f.get(base)
 		newVal := f.get(flags)
 		f.set(merged, flags)
-		overrides = append(overrides, Override{
-			Field:    f.flag,
-			OldValue: oldVal,
-			NewValue: newVal,
-		})
+		if oldVal != newVal {
+			overrides = append(overrides, Override{
+				Field:    f.flag,
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
 	}
 
 	// Bool: firewall
 	if changed["firewall"] {
-		overrides = append(overrides, Override{
-			Field:    "firewall",
-			OldValue: fmt.Sprintf("%t", base.Firewall),
-			NewValue: fmt.Sprintf("%t", flags.Firewall),
-		})
 		merged.Firewall = flags.Firewall
+		if base.Firewall != flags.Firewall {
+			overrides = append(overrides, Override{
+				Field:    "firewall",
+				OldValue: fmt.Sprintf("%t", base.Firewall),
+				NewValue: fmt.Sprintf("%t", flags.Firewall),
+			})
+		}
 	}
 
 	// Slice: feature -> Features
 	if changed["feature"] {
-		overrides = append(overrides, Override{
-			Field:    "feature",
-			OldValue: formatSlice(base.Features),
-			NewValue: formatSlice(flags.Features),
-		})
+		oldVal := formatSlice(base.Features)
+		newVal := formatSlice(flags.Features)
 		merged.Features = copySlice(flags.Features)
+		if oldVal != newVal {
+			overrides = append(overrides, Override{
+				Field:    "feature",
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
 	}
 
 	// Map: env -> EnvVars
 	if changed["env"] {
-		overrides = append(overrides, Override{
-			Field:    "env",
-			OldValue: formatEnvMap(base.EnvVars),
-			NewValue: formatEnvMap(flags.EnvVars),
-		})
+		oldVal := formatEnvMap(base.EnvVars)
+		newVal := formatEnvMap(flags.EnvVars)
 		merged.EnvVars = copyMap(flags.EnvVars)
+		if oldVal != newVal {
+			overrides = append(overrides, Override{
+				Field:    "env",
+				OldValue: oldVal,
+				NewValue: newVal,
+			})
+		}
 	}
 
 	return merged, overrides

--- a/internal/lab/override_test.go
+++ b/internal/lab/override_test.go
@@ -1,0 +1,551 @@
+package lab_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+)
+
+func TestMergeWithOverridesNoChangedFlags(t *testing.T) {
+	base := &lab.StartOptions{
+		Project: "/home/user/code/myapp",
+		Profile: "zsh",
+		Branch:  "lab/zsh",
+	}
+	flags := &lab.StartOptions{}
+	changed := map[string]bool{}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if merged.Project != base.Project {
+		t.Errorf("Project = %q, want %q", merged.Project, base.Project)
+	}
+	if merged.Profile != base.Profile {
+		t.Errorf("Profile = %q, want %q", merged.Profile, base.Profile)
+	}
+	if merged.Branch != base.Branch {
+		t.Errorf("Branch = %q, want %q", merged.Branch, base.Branch)
+	}
+	if len(overrides) != 0 {
+		t.Errorf("overrides = %v, want empty", overrides)
+	}
+}
+
+func TestMergeWithOverridesSingleStringField(t *testing.T) {
+	base := &lab.StartOptions{
+		Project: "/home/user/code/myapp",
+		Branch:  "lab/zsh",
+	}
+	flags := &lab.StartOptions{
+		Branch: "lab/experiment",
+	}
+	changed := map[string]bool{"branch": true}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if merged.Branch != "lab/experiment" {
+		t.Errorf("Branch = %q, want %q", merged.Branch, "lab/experiment")
+	}
+	if merged.Project != base.Project {
+		t.Errorf("Project = %q, want %q (unchanged)", merged.Project, base.Project)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].Field != "branch" {
+		t.Errorf("Field = %q, want %q", overrides[0].Field, "branch")
+	}
+	if overrides[0].OldValue != "lab/zsh" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "lab/zsh")
+	}
+	if overrides[0].NewValue != "lab/experiment" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "lab/experiment")
+	}
+}
+
+func TestMergeWithOverridesBoolField(t *testing.T) {
+	base := &lab.StartOptions{
+		Firewall: false,
+	}
+	flags := &lab.StartOptions{
+		Firewall: true,
+	}
+	changed := map[string]bool{"firewall": true}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if !merged.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].Field != "firewall" {
+		t.Errorf("Field = %q, want %q", overrides[0].Field, "firewall")
+	}
+	if overrides[0].OldValue != "false" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "false")
+	}
+	if overrides[0].NewValue != "true" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "true")
+	}
+}
+
+func TestMergeWithOverridesSliceField(t *testing.T) {
+	base := &lab.StartOptions{
+		Features: []string{"node:20"},
+	}
+	flags := &lab.StartOptions{
+		Features: []string{"go:1.23"},
+	}
+	changed := map[string]bool{"feature": true}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if len(merged.Features) != 1 || merged.Features[0] != "go:1.23" {
+		t.Errorf("Features = %v, want [go:1.23]", merged.Features)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].Field != "feature" {
+		t.Errorf("Field = %q, want %q", overrides[0].Field, "feature")
+	}
+	if overrides[0].OldValue != "node:20" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "node:20")
+	}
+	if overrides[0].NewValue != "go:1.23" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "go:1.23")
+	}
+}
+
+func TestMergeWithOverridesMapField(t *testing.T) {
+	base := &lab.StartOptions{
+		EnvVars: map[string]string{"API_KEY": "sk-1234"},
+	}
+	flags := &lab.StartOptions{
+		EnvVars: map[string]string{"VERBOSE": "1"},
+	}
+	changed := map[string]bool{"env": true}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if len(merged.EnvVars) != 1 || merged.EnvVars["VERBOSE"] != "1" {
+		t.Errorf("EnvVars = %v, want map[VERBOSE:1]", merged.EnvVars)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].Field != "env" {
+		t.Errorf("Field = %q, want %q", overrides[0].Field, "env")
+	}
+	if overrides[0].OldValue != "API_KEY=sk-1234" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "API_KEY=sk-1234")
+	}
+	if overrides[0].NewValue != "VERBOSE=1" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "VERBOSE=1")
+	}
+}
+
+func TestMergeWithOverridesMapFieldSortedKeys(t *testing.T) {
+	base := &lab.StartOptions{
+		EnvVars: map[string]string{"ZZZ": "last", "AAA": "first"},
+	}
+	flags := &lab.StartOptions{
+		EnvVars: map[string]string{"MMM": "mid", "BBB": "second"},
+	}
+	changed := map[string]bool{"env": true}
+
+	_, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].OldValue != "AAA=first,ZZZ=last" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "AAA=first,ZZZ=last")
+	}
+	if overrides[0].NewValue != "BBB=second,MMM=mid" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "BBB=second,MMM=mid")
+	}
+}
+
+func TestMergeWithOverridesAllFieldsOverridden(t *testing.T) {
+	base := &lab.StartOptions{
+		Project:     "/old/project",
+		Profile:     "bash",
+		Branch:      "lab/old",
+		Name:        "old-name",
+		Features:    []string{"node:18"},
+		BaseProfile: "old-base",
+		Firewall:    false,
+		InitScript:  "old.sh",
+		EnvVars:     map[string]string{"OLD": "val"},
+		EnvFile:     "old.env",
+	}
+	flags := &lab.StartOptions{
+		Project:     "/new/project",
+		Profile:     "zsh",
+		Branch:      "lab/new",
+		Name:        "new-name",
+		Features:    []string{"go:1.23"},
+		BaseProfile: "new-base",
+		Firewall:    true,
+		InitScript:  "new.sh",
+		EnvVars:     map[string]string{"NEW": "val"},
+		EnvFile:     "new.env",
+	}
+	changed := map[string]bool{
+		"project":      true,
+		"profile":      true,
+		"branch":       true,
+		"name":         true,
+		"feature":      true,
+		"base-profile": true,
+		"firewall":     true,
+		"init-script":  true,
+		"env":          true,
+		"env-file":     true,
+	}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if merged.Project != "/new/project" {
+		t.Errorf("Project = %q, want %q", merged.Project, "/new/project")
+	}
+	if merged.Profile != "zsh" {
+		t.Errorf("Profile = %q, want %q", merged.Profile, "zsh")
+	}
+	if merged.Branch != "lab/new" {
+		t.Errorf("Branch = %q, want %q", merged.Branch, "lab/new")
+	}
+	if merged.Name != "new-name" {
+		t.Errorf("Name = %q, want %q", merged.Name, "new-name")
+	}
+	if len(merged.Features) != 1 || merged.Features[0] != "go:1.23" {
+		t.Errorf("Features = %v, want [go:1.23]", merged.Features)
+	}
+	if merged.BaseProfile != "new-base" {
+		t.Errorf("BaseProfile = %q, want %q", merged.BaseProfile, "new-base")
+	}
+	if !merged.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if merged.InitScript != "new.sh" {
+		t.Errorf("InitScript = %q, want %q", merged.InitScript, "new.sh")
+	}
+	if merged.EnvVars["NEW"] != "val" {
+		t.Errorf("EnvVars = %v, want map[NEW:val]", merged.EnvVars)
+	}
+	if merged.EnvFile != "new.env" {
+		t.Errorf("EnvFile = %q, want %q", merged.EnvFile, "new.env")
+	}
+
+	if len(overrides) != 10 {
+		t.Errorf("overrides count = %d, want 10", len(overrides))
+	}
+
+	fields := make(map[string]bool)
+	for _, o := range overrides {
+		fields[o.Field] = true
+	}
+	for flag := range changed {
+		if !fields[flag] {
+			t.Errorf("missing override for flag %q", flag)
+		}
+	}
+}
+
+func TestMergeWithOverridesBaseNotMutated(t *testing.T) {
+	base := &lab.StartOptions{
+		Branch:   "lab/zsh",
+		Features: []string{"node:20", "go:1.23"},
+		EnvVars:  map[string]string{"KEY": "val"},
+	}
+	flags := &lab.StartOptions{
+		Branch:   "lab/experiment",
+		Features: []string{"rust:1"},
+		EnvVars:  map[string]string{"OTHER": "new"},
+	}
+	changed := map[string]bool{
+		"branch":  true,
+		"feature": true,
+		"env":     true,
+	}
+
+	lab.MergeWithOverrides(base, flags, changed)
+
+	if base.Branch != "lab/zsh" {
+		t.Errorf("base.Branch mutated to %q, want %q", base.Branch, "lab/zsh")
+	}
+	if len(base.Features) != 2 || base.Features[0] != "node:20" || base.Features[1] != "go:1.23" {
+		t.Errorf("base.Features mutated to %v", base.Features)
+	}
+	if base.EnvVars["KEY"] != "val" || len(base.EnvVars) != 1 {
+		t.Errorf("base.EnvVars mutated to %v", base.EnvVars)
+	}
+}
+
+func TestFormatOverridesWithOverrides(t *testing.T) {
+	preset := &lab.Preset{
+		Name:        "my-gstack",
+		Project:     "/Users/mark/code/gstack",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		BaseProfile: "base",
+		Firewall:    true,
+	}
+
+	overrides := []lab.Override{
+		{Field: "branch", OldValue: "lab/zsh", NewValue: "lab/experiment"},
+	}
+
+	output := lab.FormatOverrides(preset, overrides)
+
+	if !strings.Contains(output, "Using preset 'my-gstack'") {
+		t.Errorf("missing header line in:\n%s", output)
+	}
+	if !strings.Contains(output, "  project:") {
+		t.Errorf("missing unchanged project line in:\n%s", output)
+	}
+	if !strings.Contains(output, "  profile:") {
+		t.Errorf("missing unchanged profile line in:\n%s", output)
+	}
+	if !strings.Contains(output, "- branch:") {
+		t.Errorf("missing - branch line in:\n%s", output)
+	}
+	if !strings.Contains(output, "+ branch:") {
+		t.Errorf("missing + branch line in:\n%s", output)
+	}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "- branch:") {
+			if !strings.Contains(line, "lab/zsh") {
+				t.Errorf("- branch line should contain old value, got: %q", line)
+			}
+		}
+		if strings.Contains(line, "+ branch:") {
+			if !strings.Contains(line, "lab/experiment") {
+				t.Errorf("+ branch line should contain new value, got: %q", line)
+			}
+		}
+	}
+}
+
+func TestFormatOverridesNoOverrides(t *testing.T) {
+	preset := &lab.Preset{
+		Name:    "my-gstack",
+		Project: "/Users/mark/code/gstack",
+		Profile: "zsh",
+		Branch:  "lab/zsh",
+	}
+
+	output := lab.FormatOverrides(preset, nil)
+
+	if !strings.Contains(output, "Using preset 'my-gstack'") {
+		t.Errorf("missing header line in:\n%s", output)
+	}
+	if !strings.Contains(output, "  project:") {
+		t.Errorf("missing project line in:\n%s", output)
+	}
+	if strings.Contains(output, "- ") || strings.Contains(output, "+ ") {
+		t.Errorf("should have no diff markers in:\n%s", output)
+	}
+}
+
+func TestFormatOverridesOmitsEmptyFields(t *testing.T) {
+	preset := &lab.Preset{
+		Name:    "minimal",
+		Project: "/Users/mark/code/proj",
+		Profile: "zsh",
+	}
+
+	output := lab.FormatOverrides(preset, nil)
+
+	if !strings.Contains(output, "project:") {
+		t.Errorf("missing project in:\n%s", output)
+	}
+	if !strings.Contains(output, "profile:") {
+		t.Errorf("missing profile in:\n%s", output)
+	}
+	if strings.Contains(output, "branch:") {
+		t.Errorf("should omit empty branch in:\n%s", output)
+	}
+	if strings.Contains(output, "feature:") {
+		t.Errorf("should omit empty features in:\n%s", output)
+	}
+	if strings.Contains(output, "firewall:") {
+		t.Errorf("should omit false firewall in:\n%s", output)
+	}
+	if strings.Contains(output, "env:") {
+		t.Errorf("should omit empty env in:\n%s", output)
+	}
+	if strings.Contains(output, "env-file:") {
+		t.Errorf("should omit empty env-file in:\n%s", output)
+	}
+}
+
+func TestFormatOverridesBoolTrueToFalse(t *testing.T) {
+	preset := &lab.Preset{
+		Name:     "fw-test",
+		Project:  "/tmp/proj",
+		Firewall: true,
+	}
+
+	overrides := []lab.Override{
+		{Field: "firewall", OldValue: "true", NewValue: "false"},
+	}
+
+	output := lab.FormatOverrides(preset, overrides)
+
+	if !strings.Contains(output, "- firewall:") {
+		t.Errorf("missing - firewall line in:\n%s", output)
+	}
+	// false is zero value, so no + line
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "+ firewall:") {
+			t.Errorf("should not show + firewall for false value in:\n%s", output)
+		}
+	}
+}
+
+func TestFormatOverridesAddedField(t *testing.T) {
+	preset := &lab.Preset{
+		Name:    "no-env",
+		Project: "/tmp/proj",
+	}
+
+	overrides := []lab.Override{
+		{Field: "env", OldValue: "", NewValue: "VERBOSE=1"},
+	}
+
+	output := lab.FormatOverrides(preset, overrides)
+
+	if strings.Contains(output, "- env:") {
+		t.Errorf("should not show - env line for empty old value in:\n%s", output)
+	}
+	if !strings.Contains(output, "+ env:") {
+		t.Errorf("missing + env line in:\n%s", output)
+	}
+	if !strings.Contains(output, "VERBOSE=1") {
+		t.Errorf("missing new env value in:\n%s", output)
+	}
+}
+
+func TestMergeWithOverridesAddedFieldEmptyOldValue(t *testing.T) {
+	base := &lab.StartOptions{
+		Project: "/tmp/proj",
+	}
+	flags := &lab.StartOptions{
+		Branch: "lab/new",
+	}
+	changed := map[string]bool{"branch": true}
+
+	_, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].OldValue != "" {
+		t.Errorf("OldValue = %q, want empty string", overrides[0].OldValue)
+	}
+	if overrides[0].NewValue != "lab/new" {
+		t.Errorf("NewValue = %q, want %q", overrides[0].NewValue, "lab/new")
+	}
+}
+
+func TestMergeWithOverridesRemovedField(t *testing.T) {
+	base := &lab.StartOptions{
+		Branch: "lab/old",
+	}
+	flags := &lab.StartOptions{
+		Branch: "",
+	}
+	changed := map[string]bool{"branch": true}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if merged.Branch != "" {
+		t.Errorf("Branch = %q, want empty", merged.Branch)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("overrides count = %d, want 1", len(overrides))
+	}
+	if overrides[0].OldValue != "lab/old" {
+		t.Errorf("OldValue = %q, want %q", overrides[0].OldValue, "lab/old")
+	}
+	if overrides[0].NewValue != "" {
+		t.Errorf("NewValue = %q, want empty string", overrides[0].NewValue)
+	}
+}
+
+func TestFormatOverridesFieldOrder(t *testing.T) {
+	preset := &lab.Preset{
+		Name:        "ordered",
+		Project:     "/tmp/proj",
+		Profile:     "zsh",
+		Branch:      "lab/main",
+		BaseProfile: "base",
+		Firewall:    true,
+		EnvFile:     ".env",
+	}
+
+	output := lab.FormatOverrides(preset, nil)
+	lines := strings.Split(output, "\n")
+
+	// Find positions of each field, using the formatted label prefix to avoid
+	// substring collisions (e.g. "profile:" matching "base-profile:").
+	type labelPos struct {
+		label string
+		match string // unique substring to look for in each line
+	}
+	checks := []labelPos{
+		{"project:", "  project:"},
+		{"profile:", "  profile:"},
+		{"branch:", "  branch:"},
+		{"base-profile:", "  base-profile:"},
+		{"firewall:", "  firewall:"},
+		{"env-file:", "  env-file:"},
+	}
+
+	positions := make(map[string]int)
+	for i, line := range lines {
+		for _, c := range checks {
+			if strings.Contains(line, c.match) {
+				positions[c.label] = i
+			}
+		}
+	}
+
+	order := []string{"project:", "profile:", "branch:", "base-profile:", "firewall:", "env-file:"}
+	for i := 1; i < len(order); i++ {
+		prev := order[i-1]
+		curr := order[i]
+		if positions[prev] >= positions[curr] {
+			t.Errorf("%s (line %d) should come before %s (line %d)", prev, positions[prev], curr, positions[curr])
+		}
+	}
+}
+
+func TestFormatOverridesEnvWithOverride(t *testing.T) {
+	preset := &lab.Preset{
+		Name:    "env-test",
+		Project: "/tmp/proj",
+		EnvVars: map[string]string{"API_KEY": "sk-1234"},
+	}
+
+	overrides := []lab.Override{
+		{Field: "env", OldValue: "API_KEY=sk-1234", NewValue: "VERBOSE=1"},
+	}
+
+	output := lab.FormatOverrides(preset, overrides)
+
+	if !strings.Contains(output, "- env:") {
+		t.Errorf("missing - env line in:\n%s", output)
+	}
+	if !strings.Contains(output, "+ env:") {
+		t.Errorf("missing + env line in:\n%s", output)
+	}
+}

--- a/internal/lab/override_test.go
+++ b/internal/lab/override_test.go
@@ -549,3 +549,66 @@ func TestFormatOverridesEnvWithOverride(t *testing.T) {
 		t.Errorf("missing + env line in:\n%s", output)
 	}
 }
+
+func TestMergeWithOverridesSameValueProducesNoOverride(t *testing.T) {
+	base := &lab.StartOptions{
+		Project:  "/Users/mark/code/gstack",
+		Branch:   "lab/zsh",
+		Firewall: true,
+		Features: []string{"go:1.23"},
+		EnvVars:  map[string]string{"KEY": "val"},
+	}
+	flags := &lab.StartOptions{
+		Branch:   "lab/zsh",                       // same value
+		Firewall: true,                            // same value
+		Features: []string{"go:1.23"},             // same value
+		EnvVars:  map[string]string{"KEY": "val"}, // same value
+	}
+	changed := map[string]bool{
+		"branch":   true,
+		"firewall": true,
+		"feature":  true,
+		"env":      true,
+	}
+
+	merged, overrides := lab.MergeWithOverrides(base, flags, changed)
+
+	if len(overrides) != 0 {
+		t.Errorf("expected 0 overrides for same values, got %d: %+v", len(overrides), overrides)
+	}
+	// Merged values should still reflect the flags even though no override was recorded.
+	if merged.Branch != "lab/zsh" {
+		t.Errorf("merged.Branch = %q, want %q", merged.Branch, "lab/zsh")
+	}
+	if !merged.Firewall {
+		t.Error("merged.Firewall = false, want true")
+	}
+}
+
+func TestMergeWithOverridesFlagsNotMutated(t *testing.T) {
+	base := &lab.StartOptions{
+		Features: []string{"node:20"},
+		EnvVars:  map[string]string{"OLD": "val"},
+	}
+	flags := &lab.StartOptions{
+		Features: []string{"go:1.23"},
+		EnvVars:  map[string]string{"NEW": "val"},
+	}
+	changed := map[string]bool{
+		"feature": true,
+		"env":     true,
+	}
+
+	merged, _ := lab.MergeWithOverrides(base, flags, changed)
+
+	// Mutating merged should not affect flags.
+	merged.Features[0] = "MUTATED"
+	merged.EnvVars["INJECTED"] = "bad"
+
+	if flags.Features[0] != "go:1.23" {
+		t.Errorf("flags.Features mutated to %v", flags.Features)
+	}
+	if len(flags.EnvVars) != 1 || flags.EnvVars["NEW"] != "val" {
+		t.Errorf("flags.EnvVars mutated to %v", flags.EnvVars)
+	}
+}

--- a/internal/lab/preset.go
+++ b/internal/lab/preset.go
@@ -40,7 +40,7 @@ func (s *PresetStore) Save(p *Preset) error {
 		return err
 	}
 
-	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
 		return fmt.Errorf("create preset directory: %w", err)
 	}
 
@@ -50,7 +50,7 @@ func (s *PresetStore) Save(p *Preset) error {
 	}
 
 	path := filepath.Join(s.dir, p.Name+".json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write preset: %w", err)
 	}
 
@@ -93,6 +93,7 @@ func (s *PresetStore) List() ([]*Preset, error) {
 		name := strings.TrimSuffix(entry.Name(), ".json")
 		p, err := s.Load(name)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping unreadable preset %q: %v\n", name, err)
 			continue
 		}
 		presets = append(presets, p)
@@ -194,7 +195,7 @@ func FormatPresetFields(p *Preset) string {
 		add("init-script", p.InitScript)
 	}
 	for _, f := range p.Features {
-		add("features", f)
+		add("feature", f)
 	}
 	if len(p.EnvVars) > 0 {
 		keys := make([]string, 0, len(p.EnvVars))
@@ -203,7 +204,7 @@ func FormatPresetFields(p *Preset) string {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			add("env-vars", k+"="+p.EnvVars[k])
+			add("env", k+"="+p.EnvVars[k])
 		}
 	}
 	if p.EnvFile != "" {

--- a/internal/lab/preset.go
+++ b/internal/lab/preset.go
@@ -36,7 +36,7 @@ func NewPresetStore(dir string) *PresetStore {
 }
 
 func (s *PresetStore) Save(p *Preset) error {
-	if err := validatePresetName(p.Name); err != nil {
+	if err := ValidatePresetName(p.Name); err != nil {
 		return err
 	}
 
@@ -58,7 +58,7 @@ func (s *PresetStore) Save(p *Preset) error {
 }
 
 func (s *PresetStore) Load(name string) (*Preset, error) {
-	if err := validatePresetName(name); err != nil {
+	if err := ValidatePresetName(name); err != nil {
 		return nil, err
 	}
 
@@ -107,7 +107,7 @@ func (s *PresetStore) List() ([]*Preset, error) {
 }
 
 func (s *PresetStore) Delete(name string) error {
-	if err := validatePresetName(name); err != nil {
+	if err := ValidatePresetName(name); err != nil {
 		return err
 	}
 
@@ -118,7 +118,8 @@ func (s *PresetStore) Delete(name string) error {
 	return nil
 }
 
-func validatePresetName(name string) error {
+// ValidatePresetName checks whether name is a valid preset name.
+func ValidatePresetName(name string) error {
 	if name == "" {
 		return fmt.Errorf("preset name must not be empty")
 	}

--- a/internal/lab/preset.go
+++ b/internal/lab/preset.go
@@ -1,0 +1,214 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Preset holds a reusable lab configuration.
+type Preset struct {
+	Name        string            `json:"name"`
+	CreatedAt   time.Time         `json:"created_at"`
+	Project     string            `json:"project"`
+	Profile     string            `json:"profile"`
+	Branch      string            `json:"branch"`
+	LabName     string            `json:"name_flag"`
+	Features    []string          `json:"features,omitempty"`
+	BaseProfile string            `json:"base_profile,omitempty"`
+	Firewall    bool              `json:"firewall,omitempty"`
+	InitScript  string            `json:"init_script,omitempty"`
+	EnvVars     map[string]string `json:"env_vars,omitempty"`
+	EnvFile     string            `json:"env_file,omitempty"`
+}
+
+// PresetStore reads and writes preset JSON files in a directory.
+type PresetStore struct {
+	dir string
+}
+
+func NewPresetStore(dir string) *PresetStore {
+	return &PresetStore{dir: dir}
+}
+
+func (s *PresetStore) Save(p *Preset) error {
+	if err := validatePresetName(p.Name); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return fmt.Errorf("create preset directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal preset: %w", err)
+	}
+
+	path := filepath.Join(s.dir, p.Name+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write preset: %w", err)
+	}
+
+	return nil
+}
+
+func (s *PresetStore) Load(name string) (*Preset, error) {
+	if err := validatePresetName(name); err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(s.dir, name+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read preset %q: %w", name, err)
+	}
+
+	var p Preset
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse preset %q: %w", name, err)
+	}
+
+	return &p, nil
+}
+
+func (s *PresetStore) List() ([]*Preset, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []*Preset{}, nil
+		}
+		return nil, fmt.Errorf("read preset directory: %w", err)
+	}
+
+	presets := make([]*Preset, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		p, err := s.Load(name)
+		if err != nil {
+			continue
+		}
+		presets = append(presets, p)
+	}
+
+	return presets, nil
+}
+
+func (s *PresetStore) Delete(name string) error {
+	if err := validatePresetName(name); err != nil {
+		return err
+	}
+
+	path := filepath.Join(s.dir, name+".json")
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("delete preset %q: %w", name, err)
+	}
+	return nil
+}
+
+func validatePresetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
+	}
+	if strings.HasPrefix(name, ".") {
+		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "..") || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
+	}
+	if !validNameRegex.MatchString(name) {
+		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
+	}
+	return nil
+}
+
+// PresetFromStartOptions creates a Preset from a name and StartOptions.
+func PresetFromStartOptions(name string, opts *StartOptions) *Preset {
+	return &Preset{
+		Name:        name,
+		CreatedAt:   time.Now().UTC(),
+		Project:     opts.Project,
+		Profile:     opts.Profile,
+		Branch:      opts.Branch,
+		LabName:     opts.Name,
+		Features:    opts.Features,
+		BaseProfile: opts.BaseProfile,
+		Firewall:    opts.Firewall,
+		InitScript:  opts.InitScript,
+		EnvVars:     opts.EnvVars,
+		EnvFile:     opts.EnvFile,
+	}
+}
+
+// ToStartOptions converts a Preset back to StartOptions.
+func (p *Preset) ToStartOptions() *StartOptions {
+	return &StartOptions{
+		Project:     p.Project,
+		Profile:     p.Profile,
+		Branch:      p.Branch,
+		Name:        p.LabName,
+		Features:    p.Features,
+		BaseProfile: p.BaseProfile,
+		Firewall:    p.Firewall,
+		InitScript:  p.InitScript,
+		EnvVars:     p.EnvVars,
+		EnvFile:     p.EnvFile,
+	}
+}
+
+// FormatPresetFields renders a key:value aligned field listing for a preset.
+// Only non-zero fields are included. Callers prepend their own header line.
+func FormatPresetFields(p *Preset) string {
+	var lines []string
+
+	add := func(label, value string) {
+		lines = append(lines, fmt.Sprintf("  %-14s%s", label+":", value))
+	}
+
+	if p.Project != "" {
+		add("project", p.Project)
+	}
+	if p.Profile != "" {
+		add("profile", p.Profile)
+	}
+	if p.Branch != "" {
+		add("branch", p.Branch)
+	}
+	if p.LabName != "" {
+		add("lab-name", p.LabName)
+	}
+	if p.BaseProfile != "" {
+		add("base-profile", p.BaseProfile)
+	}
+	if p.Firewall {
+		add("firewall", "true")
+	}
+	if p.InitScript != "" {
+		add("init-script", p.InitScript)
+	}
+	for _, f := range p.Features {
+		add("features", f)
+	}
+	if len(p.EnvVars) > 0 {
+		keys := make([]string, 0, len(p.EnvVars))
+		for k := range p.EnvVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			add("env-vars", k+"="+p.EnvVars[k])
+		}
+	}
+	if p.EnvFile != "" {
+		add("env-file", p.EnvFile)
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/lab/preset.go
+++ b/internal/lab/preset.go
@@ -187,7 +187,7 @@ func FormatPresetFields(p *Preset) string {
 		add("branch", p.Branch)
 	}
 	if p.LabName != "" {
-		add("lab-name", p.LabName)
+		add("name", p.LabName)
 	}
 	if p.BaseProfile != "" {
 		add("base-profile", p.BaseProfile)

--- a/internal/lab/preset.go
+++ b/internal/lab/preset.go
@@ -99,6 +99,10 @@ func (s *PresetStore) List() ([]*Preset, error) {
 		presets = append(presets, p)
 	}
 
+	sort.Slice(presets, func(i, j int) bool {
+		return presets[i].Name < presets[j].Name
+	})
+
 	return presets, nil
 }
 
@@ -116,7 +120,7 @@ func (s *PresetStore) Delete(name string) error {
 
 func validatePresetName(name string) error {
 	if name == "" {
-		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
+		return fmt.Errorf("preset name must not be empty")
 	}
 	if strings.HasPrefix(name, ".") {
 		return fmt.Errorf("preset name %q contains invalid characters (allowed: A-Z, a-z, 0-9, '.', '_', '-')", name)
@@ -139,11 +143,11 @@ func PresetFromStartOptions(name string, opts *StartOptions) *Preset {
 		Profile:     opts.Profile,
 		Branch:      opts.Branch,
 		LabName:     opts.Name,
-		Features:    opts.Features,
+		Features:    copySlice(opts.Features),
 		BaseProfile: opts.BaseProfile,
 		Firewall:    opts.Firewall,
 		InitScript:  opts.InitScript,
-		EnvVars:     opts.EnvVars,
+		EnvVars:     copyMap(opts.EnvVars),
 		EnvFile:     opts.EnvFile,
 	}
 }
@@ -155,11 +159,11 @@ func (p *Preset) ToStartOptions() *StartOptions {
 		Profile:     p.Profile,
 		Branch:      p.Branch,
 		Name:        p.LabName,
-		Features:    p.Features,
+		Features:    copySlice(p.Features),
 		BaseProfile: p.BaseProfile,
 		Firewall:    p.Firewall,
 		InitScript:  p.InitScript,
-		EnvVars:     p.EnvVars,
+		EnvVars:     copyMap(p.EnvVars),
 		EnvFile:     p.EnvFile,
 	}
 }

--- a/internal/lab/preset_test.go
+++ b/internal/lab/preset_test.go
@@ -435,3 +435,57 @@ func TestFormatPresetFieldsRepeatedValues(t *testing.T) {
 		t.Errorf("third env-var line should contain ZZZ=last, got %q", envLines[2])
 	}
 }
+
+func TestPresetFromStartOptionsDeepCopy(t *testing.T) {
+	opts := &lab.StartOptions{
+		Features: []string{"go:1.23"},
+		EnvVars:  map[string]string{"KEY": "val"},
+	}
+
+	p := lab.PresetFromStartOptions("test", opts)
+
+	// Mutating opts should not affect the preset.
+	opts.Features[0] = "MUTATED"
+	opts.EnvVars["INJECTED"] = "bad"
+
+	if p.Features[0] != "go:1.23" {
+		t.Errorf("preset.Features mutated to %v", p.Features)
+	}
+	if len(p.EnvVars) != 1 || p.EnvVars["KEY"] != "val" {
+		t.Errorf("preset.EnvVars mutated to %v", p.EnvVars)
+	}
+}
+
+func TestToStartOptionsDeepCopy(t *testing.T) {
+	p := &lab.Preset{
+		Name:     "test",
+		Features: []string{"go:1.23"},
+		EnvVars:  map[string]string{"KEY": "val"},
+	}
+
+	opts := p.ToStartOptions()
+
+	// Mutating opts should not affect the preset.
+	opts.Features[0] = "MUTATED"
+	opts.EnvVars["INJECTED"] = "bad"
+
+	if p.Features[0] != "go:1.23" {
+		t.Errorf("preset.Features mutated to %v", p.Features)
+	}
+	if len(p.EnvVars) != 1 || p.EnvVars["KEY"] != "val" {
+		t.Errorf("preset.EnvVars mutated to %v", p.EnvVars)
+	}
+}
+
+func TestValidatePresetNameEmptyDistinctMessage(t *testing.T) {
+	// Use Save with empty name to trigger validation.
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+	err := store.Save(&lab.Preset{Name: ""})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("expected 'must not be empty' message, got: %s", err.Error())
+	}
+}

--- a/internal/lab/preset_test.go
+++ b/internal/lab/preset_test.go
@@ -1,0 +1,437 @@
+package lab_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/claudeup/claudeup-lab/internal/lab"
+)
+
+func TestPresetSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	preset := &lab.Preset{
+		Name:        "my-preset",
+		CreatedAt:   time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC),
+		Project:     "/home/user/code/myapp",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		LabName:     "myapp-zsh",
+		Features:    []string{"ghcr.io/devcontainers/features/go:1"},
+		BaseProfile: "base",
+		Firewall:    true,
+		InitScript:  "setup.sh",
+		EnvVars:     map[string]string{"FOO": "bar", "BAZ": "qux"},
+		EnvFile:     ".env.local",
+	}
+
+	if err := store.Save(preset); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load("my-preset")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.Name != preset.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, preset.Name)
+	}
+	if !loaded.CreatedAt.Equal(preset.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", loaded.CreatedAt, preset.CreatedAt)
+	}
+	if loaded.Project != preset.Project {
+		t.Errorf("Project = %q, want %q", loaded.Project, preset.Project)
+	}
+	if loaded.Profile != preset.Profile {
+		t.Errorf("Profile = %q, want %q", loaded.Profile, preset.Profile)
+	}
+	if loaded.Branch != preset.Branch {
+		t.Errorf("Branch = %q, want %q", loaded.Branch, preset.Branch)
+	}
+	if loaded.LabName != preset.LabName {
+		t.Errorf("LabName = %q, want %q", loaded.LabName, preset.LabName)
+	}
+	if len(loaded.Features) != 1 || loaded.Features[0] != preset.Features[0] {
+		t.Errorf("Features = %v, want %v", loaded.Features, preset.Features)
+	}
+	if loaded.BaseProfile != preset.BaseProfile {
+		t.Errorf("BaseProfile = %q, want %q", loaded.BaseProfile, preset.BaseProfile)
+	}
+	if !loaded.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if loaded.InitScript != preset.InitScript {
+		t.Errorf("InitScript = %q, want %q", loaded.InitScript, preset.InitScript)
+	}
+	if loaded.EnvVars["FOO"] != "bar" || loaded.EnvVars["BAZ"] != "qux" {
+		t.Errorf("EnvVars = %v, want %v", loaded.EnvVars, preset.EnvVars)
+	}
+	if loaded.EnvFile != preset.EnvFile {
+		t.Errorf("EnvFile = %q, want %q", loaded.EnvFile, preset.EnvFile)
+	}
+}
+
+func TestPresetListAll(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	store.Save(&lab.Preset{Name: "alpha", Project: "/a"})
+	store.Save(&lab.Preset{Name: "beta", Project: "/b"})
+	store.Save(&lab.Preset{Name: "gamma", Project: "/c"})
+
+	presets, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(presets) != 3 {
+		t.Fatalf("List returned %d presets, want 3", len(presets))
+	}
+
+	names := make(map[string]bool)
+	for _, p := range presets {
+		names[p.Name] = true
+	}
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if !names[want] {
+			t.Errorf("List missing preset %q", want)
+		}
+	}
+}
+
+func TestPresetListNonexistentDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does", "not", "exist")
+	store := lab.NewPresetStore(dir)
+
+	presets, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if presets == nil {
+		t.Error("List returned nil, want empty slice")
+	}
+	if len(presets) != 0 {
+		t.Errorf("List returned %d presets, want 0", len(presets))
+	}
+}
+
+func TestPresetListEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	presets, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if presets == nil {
+		t.Error("List returned nil, want empty slice")
+	}
+	if len(presets) != 0 {
+		t.Errorf("List returned %d presets, want 0", len(presets))
+	}
+}
+
+func TestPresetDelete(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	store.Save(&lab.Preset{Name: "to-delete", Project: "/tmp"})
+
+	if err := store.Delete("to-delete"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err := store.Load("to-delete")
+	if err == nil {
+		t.Error("Load after Delete should return error")
+	}
+}
+
+func TestPresetLoadNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	_, err := store.Load("does-not-exist")
+	if err == nil {
+		t.Error("Load nonexistent should return error")
+	}
+}
+
+func TestPresetSaveCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "presets")
+	store := lab.NewPresetStore(dir)
+
+	err := store.Save(&lab.Preset{Name: "test", Project: "/tmp"})
+	if err != nil {
+		t.Fatalf("Save to nested dir: %v", err)
+	}
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Error("Save should create preset directory")
+	}
+}
+
+func TestPresetOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	store.Save(&lab.Preset{Name: "foo", Project: "/original"})
+	store.Save(&lab.Preset{Name: "foo", Project: "/updated"})
+
+	loaded, err := store.Load("foo")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Project != "/updated" {
+		t.Errorf("Project = %q, want %q", loaded.Project, "/updated")
+	}
+}
+
+func TestPresetNameValidationRejectsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	invalid := []string{"", "../etc", "foo/bar", ".hidden", "has spaces", "has@special"}
+
+	for _, name := range invalid {
+		t.Run("save_"+name, func(t *testing.T) {
+			err := store.Save(&lab.Preset{Name: name, Project: "/tmp"})
+			if err == nil {
+				t.Errorf("Save(%q) should return error", name)
+			}
+		})
+		t.Run("load_"+name, func(t *testing.T) {
+			_, err := store.Load(name)
+			if err == nil {
+				t.Errorf("Load(%q) should return error", name)
+			}
+		})
+		t.Run("delete_"+name, func(t *testing.T) {
+			err := store.Delete(name)
+			if err == nil {
+				t.Errorf("Delete(%q) should return error", name)
+			}
+		})
+	}
+}
+
+func TestPresetNameValidationAcceptsValid(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewPresetStore(dir)
+
+	valid := []string{"my-preset", "test_config", "v1.0", "ABC123"}
+
+	for _, name := range valid {
+		t.Run(name, func(t *testing.T) {
+			err := store.Save(&lab.Preset{Name: name, Project: "/tmp"})
+			if err != nil {
+				t.Errorf("Save(%q) should succeed, got: %v", name, err)
+			}
+			_, err = store.Load(name)
+			if err != nil {
+				t.Errorf("Load(%q) should succeed, got: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestPresetFromStartOptions(t *testing.T) {
+	opts := &lab.StartOptions{
+		Project:     "/home/user/code/gstack",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		Name:        "gstack-zsh",
+		Features:    []string{"ghcr.io/devcontainers/features/go:1"},
+		BaseProfile: "base",
+		Firewall:    true,
+		InitScript:  "setup.sh",
+		EnvVars:     map[string]string{"KEY": "val"},
+		EnvFile:     ".env",
+	}
+
+	before := time.Now().UTC()
+	preset := lab.PresetFromStartOptions("my-config", opts)
+	after := time.Now().UTC()
+
+	if preset.Name != "my-config" {
+		t.Errorf("Name = %q, want %q", preset.Name, "my-config")
+	}
+	if preset.CreatedAt.Before(before) || preset.CreatedAt.After(after) {
+		t.Errorf("CreatedAt = %v, want between %v and %v", preset.CreatedAt, before, after)
+	}
+	if preset.Project != opts.Project {
+		t.Errorf("Project = %q, want %q", preset.Project, opts.Project)
+	}
+	if preset.Profile != opts.Profile {
+		t.Errorf("Profile = %q, want %q", preset.Profile, opts.Profile)
+	}
+	if preset.Branch != opts.Branch {
+		t.Errorf("Branch = %q, want %q", preset.Branch, opts.Branch)
+	}
+	if preset.LabName != opts.Name {
+		t.Errorf("LabName = %q, want %q", preset.LabName, opts.Name)
+	}
+	if len(preset.Features) != 1 || preset.Features[0] != opts.Features[0] {
+		t.Errorf("Features = %v, want %v", preset.Features, opts.Features)
+	}
+	if preset.BaseProfile != opts.BaseProfile {
+		t.Errorf("BaseProfile = %q, want %q", preset.BaseProfile, opts.BaseProfile)
+	}
+	if !preset.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if preset.InitScript != opts.InitScript {
+		t.Errorf("InitScript = %q, want %q", preset.InitScript, opts.InitScript)
+	}
+	if preset.EnvVars["KEY"] != "val" {
+		t.Errorf("EnvVars = %v, want %v", preset.EnvVars, opts.EnvVars)
+	}
+	if preset.EnvFile != opts.EnvFile {
+		t.Errorf("EnvFile = %q, want %q", preset.EnvFile, opts.EnvFile)
+	}
+}
+
+func TestPresetToStartOptions(t *testing.T) {
+	preset := &lab.Preset{
+		Name:        "my-config",
+		Project:     "/home/user/code/gstack",
+		Profile:     "zsh",
+		Branch:      "lab/zsh",
+		LabName:     "gstack-zsh",
+		Features:    []string{"ghcr.io/devcontainers/features/go:1"},
+		BaseProfile: "base",
+		Firewall:    true,
+		InitScript:  "setup.sh",
+		EnvVars:     map[string]string{"KEY": "val"},
+		EnvFile:     ".env",
+	}
+
+	opts := preset.ToStartOptions()
+
+	if opts.Project != preset.Project {
+		t.Errorf("Project = %q, want %q", opts.Project, preset.Project)
+	}
+	if opts.Profile != preset.Profile {
+		t.Errorf("Profile = %q, want %q", opts.Profile, preset.Profile)
+	}
+	if opts.Branch != preset.Branch {
+		t.Errorf("Branch = %q, want %q", opts.Branch, preset.Branch)
+	}
+	if opts.Name != preset.LabName {
+		t.Errorf("Name = %q, want %q", opts.Name, preset.LabName)
+	}
+	if len(opts.Features) != 1 || opts.Features[0] != preset.Features[0] {
+		t.Errorf("Features = %v, want %v", opts.Features, preset.Features)
+	}
+	if opts.BaseProfile != preset.BaseProfile {
+		t.Errorf("BaseProfile = %q, want %q", opts.BaseProfile, preset.BaseProfile)
+	}
+	if !opts.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if opts.InitScript != preset.InitScript {
+		t.Errorf("InitScript = %q, want %q", opts.InitScript, preset.InitScript)
+	}
+	if opts.EnvVars["KEY"] != "val" {
+		t.Errorf("EnvVars = %v, want %v", opts.EnvVars, preset.EnvVars)
+	}
+	if opts.EnvFile != preset.EnvFile {
+		t.Errorf("EnvFile = %q, want %q", opts.EnvFile, preset.EnvFile)
+	}
+}
+
+func TestFormatPresetFieldsNonZero(t *testing.T) {
+	preset := &lab.Preset{
+		Project:  "/Users/mark/code/gstack",
+		Profile:  "zsh",
+		Branch:   "lab/zsh",
+		Firewall: true,
+	}
+
+	output := lab.FormatPresetFields(preset)
+
+	expected := []string{
+		"  project:      /Users/mark/code/gstack",
+		"  profile:      zsh",
+		"  branch:       lab/zsh",
+		"  firewall:     true",
+	}
+
+	for _, line := range expected {
+		if !strings.Contains(output, line) {
+			t.Errorf("output missing line %q\ngot:\n%s", line, output)
+		}
+	}
+}
+
+func TestFormatPresetFieldsOmitsZero(t *testing.T) {
+	preset := &lab.Preset{
+		Project: "/Users/mark/code/gstack",
+		Profile: "zsh",
+	}
+
+	output := lab.FormatPresetFields(preset)
+
+	if strings.Contains(output, "branch:") {
+		t.Errorf("output should omit branch, got:\n%s", output)
+	}
+	if strings.Contains(output, "features:") {
+		t.Errorf("output should omit features, got:\n%s", output)
+	}
+	if strings.Contains(output, "firewall:") {
+		t.Errorf("output should omit firewall, got:\n%s", output)
+	}
+	if strings.Contains(output, "env-vars:") {
+		t.Errorf("output should omit env-vars, got:\n%s", output)
+	}
+	if strings.Contains(output, "env-file:") {
+		t.Errorf("output should omit env-file, got:\n%s", output)
+	}
+	if strings.Contains(output, "init-script:") {
+		t.Errorf("output should omit init-script, got:\n%s", output)
+	}
+}
+
+func TestFormatPresetFieldsRepeatedValues(t *testing.T) {
+	preset := &lab.Preset{
+		Project:  "/tmp/proj",
+		Features: []string{"feat-a", "feat-b"},
+		EnvVars:  map[string]string{"ZZZ": "last", "AAA": "first", "MMM": "mid"},
+	}
+
+	output := lab.FormatPresetFields(preset)
+
+	// Each feature on its own line
+	if strings.Count(output, "features:") != 2 {
+		t.Errorf("expected 2 features: lines, got %d in:\n%s", strings.Count(output, "features:"), output)
+	}
+
+	// Env vars sorted alphabetically
+	if strings.Count(output, "env-vars:") != 3 {
+		t.Errorf("expected 3 env-vars: lines, got %d in:\n%s", strings.Count(output, "env-vars:"), output)
+	}
+
+	lines := strings.Split(output, "\n")
+	var envLines []string
+	for _, line := range lines {
+		if strings.Contains(line, "env-vars:") {
+			envLines = append(envLines, line)
+		}
+	}
+	if len(envLines) != 3 {
+		t.Fatalf("expected 3 env-var lines, got %d", len(envLines))
+	}
+	if !strings.Contains(envLines[0], "AAA=first") {
+		t.Errorf("first env-var line should contain AAA=first, got %q", envLines[0])
+	}
+	if !strings.Contains(envLines[1], "MMM=mid") {
+		t.Errorf("second env-var line should contain MMM=mid, got %q", envLines[1])
+	}
+	if !strings.Contains(envLines[2], "ZZZ=last") {
+		t.Errorf("third env-var line should contain ZZZ=last, got %q", envLines[2])
+	}
+}

--- a/internal/lab/preset_test.go
+++ b/internal/lab/preset_test.go
@@ -379,14 +379,14 @@ func TestFormatPresetFieldsOmitsZero(t *testing.T) {
 	if strings.Contains(output, "branch:") {
 		t.Errorf("output should omit branch, got:\n%s", output)
 	}
-	if strings.Contains(output, "features:") {
-		t.Errorf("output should omit features, got:\n%s", output)
+	if strings.Contains(output, "feature:") {
+		t.Errorf("output should omit feature, got:\n%s", output)
 	}
 	if strings.Contains(output, "firewall:") {
 		t.Errorf("output should omit firewall, got:\n%s", output)
 	}
-	if strings.Contains(output, "env-vars:") {
-		t.Errorf("output should omit env-vars, got:\n%s", output)
+	if strings.Contains(output, "env:") {
+		t.Errorf("output should omit env, got:\n%s", output)
 	}
 	if strings.Contains(output, "env-file:") {
 		t.Errorf("output should omit env-file, got:\n%s", output)
@@ -406,19 +406,19 @@ func TestFormatPresetFieldsRepeatedValues(t *testing.T) {
 	output := lab.FormatPresetFields(preset)
 
 	// Each feature on its own line
-	if strings.Count(output, "features:") != 2 {
-		t.Errorf("expected 2 features: lines, got %d in:\n%s", strings.Count(output, "features:"), output)
+	if strings.Count(output, "feature:") != 2 {
+		t.Errorf("expected 2 feature: lines, got %d in:\n%s", strings.Count(output, "feature:"), output)
 	}
 
 	// Env vars sorted alphabetically
-	if strings.Count(output, "env-vars:") != 3 {
-		t.Errorf("expected 3 env-vars: lines, got %d in:\n%s", strings.Count(output, "env-vars:"), output)
+	if strings.Count(output, "env:") != 3 {
+		t.Errorf("expected 3 env: lines, got %d in:\n%s", strings.Count(output, "env:"), output)
 	}
 
 	lines := strings.Split(output, "\n")
 	var envLines []string
 	for _, line := range lines {
-		if strings.Contains(line, "env-vars:") {
+		if strings.Contains(line, "env:") {
 			envLines = append(envLines, line)
 		}
 	}

--- a/internal/lab/state.go
+++ b/internal/lab/state.go
@@ -9,18 +9,35 @@ import (
 	"time"
 )
 
+// StartConfig records the fully resolved start flags for a lab instance.
+// Stored as part of Metadata so that preset save --from-lab can reconstruct
+// the exact configuration that was used to start the lab.
+type StartConfig struct {
+	Project     string            `json:"project"`
+	Profile     string            `json:"profile"`
+	Branch      string            `json:"branch"`
+	LabName     string            `json:"name_flag"`
+	Features    []string          `json:"features,omitempty"`
+	BaseProfile string            `json:"base_profile,omitempty"`
+	Firewall    bool              `json:"firewall,omitempty"`
+	InitScript  string            `json:"init_script,omitempty"`
+	EnvVars     map[string]string `json:"env_vars,omitempty"`
+	EnvFile     string            `json:"env_file,omitempty"`
+}
+
 // Metadata holds persisted state for a single lab instance.
 type Metadata struct {
-	ID          string    `json:"id"`
-	DisplayName string    `json:"display_name"`
-	Project     string    `json:"project"`
-	ProjectName string    `json:"project_name"`
-	Profile     string    `json:"profile"`
-	BareRepo    string    `json:"bare_repo"`
-	Worktree    string    `json:"worktree"`
-	Branch      string    `json:"branch"`
-	Created     time.Time `json:"created"`
-	Snapshot    string    `json:"snapshot,omitempty"`
+	ID          string       `json:"id"`
+	DisplayName string       `json:"display_name"`
+	Project     string       `json:"project"`
+	ProjectName string       `json:"project_name"`
+	Profile     string       `json:"profile"`
+	BareRepo    string       `json:"bare_repo"`
+	Worktree    string       `json:"worktree"`
+	Branch      string       `json:"branch"`
+	Created     time.Time    `json:"created"`
+	Snapshot    string       `json:"snapshot,omitempty"`
+	StartConfig *StartConfig `json:"start_config,omitempty"`
 }
 
 // StateStore reads and writes lab metadata JSON files in a directory.

--- a/internal/lab/state_test.go
+++ b/internal/lab/state_test.go
@@ -109,3 +109,227 @@ func TestSaveCreatesDirectory(t *testing.T) {
 		t.Error("Save should create state directory")
 	}
 }
+
+func TestStartConfigRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewStateStore(dir)
+
+	envFilePath := "/home/user/config/vars"
+	meta := &lab.Metadata{
+		ID:          "cfg-001",
+		DisplayName: "myapp-zsh",
+		Project:     "/home/user/code/myapp",
+		ProjectName: "myapp",
+		Profile:     "zsh",
+		BareRepo:    "/home/user/.claudeup-lab/repos/myapp.git",
+		Worktree:    "/home/user/.claudeup-lab/workspaces/myapp-zsh",
+		Branch:      "lab/zsh",
+		Created:     time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC),
+		StartConfig: &lab.StartConfig{
+			Project:     "/home/user/code/myapp",
+			Profile:     "zsh",
+			Branch:      "lab/zsh",
+			LabName:     "myapp-zsh",
+			Features:    []string{"ghcr.io/devcontainers/features/node:1"},
+			BaseProfile: "base",
+			Firewall:    true,
+			InitScript:  "/home/user/init.sh",
+			EnvVars:     map[string]string{"FOO": "bar", "BAZ": "qux"},
+			EnvFile:     envFilePath,
+		},
+	}
+
+	if err := store.Save(meta); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load("cfg-001")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.StartConfig == nil {
+		t.Fatal("StartConfig is nil after round-trip")
+	}
+
+	sc := loaded.StartConfig
+	if sc.Project != "/home/user/code/myapp" {
+		t.Errorf("Project = %q, want %q", sc.Project, "/home/user/code/myapp")
+	}
+	if sc.Profile != "zsh" {
+		t.Errorf("Profile = %q, want %q", sc.Profile, "zsh")
+	}
+	if sc.Branch != "lab/zsh" {
+		t.Errorf("Branch = %q, want %q", sc.Branch, "lab/zsh")
+	}
+	if sc.LabName != "myapp-zsh" {
+		t.Errorf("LabName = %q, want %q", sc.LabName, "myapp-zsh")
+	}
+	if len(sc.Features) != 1 || sc.Features[0] != "ghcr.io/devcontainers/features/node:1" {
+		t.Errorf("Features = %v, want [ghcr.io/devcontainers/features/node:1]", sc.Features)
+	}
+	if sc.BaseProfile != "base" {
+		t.Errorf("BaseProfile = %q, want %q", sc.BaseProfile, "base")
+	}
+	if !sc.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if sc.InitScript != "/home/user/init.sh" {
+		t.Errorf("InitScript = %q, want %q", sc.InitScript, "/home/user/init.sh")
+	}
+	if sc.EnvVars["FOO"] != "bar" || sc.EnvVars["BAZ"] != "qux" {
+		t.Errorf("EnvVars = %v, want map[FOO:bar BAZ:qux]", sc.EnvVars)
+	}
+	if sc.EnvFile != envFilePath {
+		t.Errorf("EnvFile = %q, want %q", sc.EnvFile, envFilePath)
+	}
+}
+
+func TestStartConfigNilWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	store := lab.NewStateStore(dir)
+
+	meta := &lab.Metadata{
+		ID:          "no-cfg",
+		DisplayName: "plain-lab",
+		Project:     "/tmp/project",
+		ProjectName: "project",
+		Profile:     "default",
+		Branch:      "lab/default",
+		Created:     time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC),
+	}
+
+	if err := store.Save(meta); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.Load("no-cfg")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.StartConfig != nil {
+		t.Errorf("StartConfig = %+v, want nil", loaded.StartConfig)
+	}
+}
+
+func TestStartConfigBackwardCompatibility(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a pre-feature state file with no start_config key
+	rawJSON := `{
+  "id": "legacy-001",
+  "display_name": "old-lab",
+  "project": "/home/user/code/old",
+  "project_name": "old",
+  "profile": "base",
+  "bare_repo": "/home/user/.claudeup-lab/repos/old.git",
+  "worktree": "/home/user/.claudeup-lab/workspaces/old-lab",
+  "branch": "lab/base",
+  "created": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(dir, "legacy-001.json"), []byte(rawJSON), 0o644); err != nil {
+		t.Fatalf("write raw JSON: %v", err)
+	}
+
+	store := lab.NewStateStore(dir)
+	loaded, err := store.Load("legacy-001")
+	if err != nil {
+		t.Fatalf("Load legacy state: %v", err)
+	}
+
+	if loaded.StartConfig != nil {
+		t.Errorf("StartConfig = %+v, want nil for legacy state file", loaded.StartConfig)
+	}
+	if loaded.DisplayName != "old-lab" {
+		t.Errorf("DisplayName = %q, want %q", loaded.DisplayName, "old-lab")
+	}
+	if loaded.Branch != "lab/base" {
+		t.Errorf("Branch = %q, want %q", loaded.Branch, "lab/base")
+	}
+}
+
+func TestStartConfigFromResolved(t *testing.T) {
+	envFilePath := "/home/user/config/local-vars"
+	opts := &lab.StartOptions{
+		Project:     "./relative/path", // raw, should be ignored
+		Profile:     "",                // raw, should be ignored
+		Branch:      "",                // raw, should be ignored
+		Name:        "custom-name",
+		Features:    []string{"feat-a", "feat-b"},
+		BaseProfile: "minimal",
+		Firewall:    true,
+		InitScript:  "/scripts/init.sh",
+		EnvVars:     map[string]string{"KEY": "val"},
+		EnvFile:     envFilePath,
+	}
+
+	cfg := lab.StartConfigFromResolved("/abs/path/to/project", "zsh", "lab/zsh", opts)
+
+	// Resolved params take priority over opts fields
+	if cfg.Project != "/abs/path/to/project" {
+		t.Errorf("Project = %q, want %q", cfg.Project, "/abs/path/to/project")
+	}
+	if cfg.Profile != "zsh" {
+		t.Errorf("Profile = %q, want %q", cfg.Profile, "zsh")
+	}
+	if cfg.Branch != "lab/zsh" {
+		t.Errorf("Branch = %q, want %q", cfg.Branch, "lab/zsh")
+	}
+
+	// Remaining fields from opts
+	if cfg.LabName != "custom-name" {
+		t.Errorf("LabName = %q, want %q", cfg.LabName, "custom-name")
+	}
+	if len(cfg.Features) != 2 || cfg.Features[0] != "feat-a" || cfg.Features[1] != "feat-b" {
+		t.Errorf("Features = %v, want [feat-a feat-b]", cfg.Features)
+	}
+	if cfg.BaseProfile != "minimal" {
+		t.Errorf("BaseProfile = %q, want %q", cfg.BaseProfile, "minimal")
+	}
+	if !cfg.Firewall {
+		t.Error("Firewall = false, want true")
+	}
+	if cfg.InitScript != "/scripts/init.sh" {
+		t.Errorf("InitScript = %q, want %q", cfg.InitScript, "/scripts/init.sh")
+	}
+	if cfg.EnvVars["KEY"] != "val" {
+		t.Errorf("EnvVars = %v, want map[KEY:val]", cfg.EnvVars)
+	}
+	if cfg.EnvFile != envFilePath {
+		t.Errorf("EnvFile = %q, want %q", cfg.EnvFile, envFilePath)
+	}
+}
+
+func TestStartConfigFromResolvedOmitsEmptyOptionals(t *testing.T) {
+	opts := &lab.StartOptions{
+		Project: ".",
+		Profile: "default",
+		Branch:  "main",
+		Name:    "",
+	}
+
+	cfg := lab.StartConfigFromResolved("/abs/project", "default", "lab/default", opts)
+
+	if cfg.LabName != "" {
+		t.Errorf("LabName = %q, want empty", cfg.LabName)
+	}
+	if cfg.Features != nil {
+		t.Errorf("Features = %v, want nil", cfg.Features)
+	}
+	if cfg.BaseProfile != "" {
+		t.Errorf("BaseProfile = %q, want empty", cfg.BaseProfile)
+	}
+	if cfg.Firewall {
+		t.Error("Firewall = true, want false")
+	}
+	if cfg.InitScript != "" {
+		t.Errorf("InitScript = %q, want empty", cfg.InitScript)
+	}
+	if cfg.EnvVars != nil {
+		t.Errorf("EnvVars = %v, want nil", cfg.EnvVars)
+	}
+	if cfg.EnvFile != "" {
+		t.Errorf("EnvFile = %q, want empty", cfg.EnvFile)
+	}
+}


### PR DESCRIPTION
## Summary

- Add named presets that persist lab start configurations, eliminating repetitive long commands
- `preset save` captures configs from explicit flags or from a running/stopped lab via `--from-lab`
- `start [preset-name]` launches labs from saved presets with optional flag overrides shown in diff-style output
- `preset list`, `preset show`, and `preset delete` for full preset lifecycle management
- Lab start configurations are automatically tracked per-lab and cleaned up on deletion

## New Commands

- `claudeup-lab preset save <name> [--from-lab <lab>] [flags]` -- save a preset
- `claudeup-lab preset list` (alias: `ls`) -- tabular summary of presets
- `claudeup-lab preset show <name>` -- full preset details
- `claudeup-lab preset delete <name>` -- delete with confirmation
- `claudeup-lab start [preset-name] [flags]` -- start from preset with override support

## Architecture

- `internal/lab/preset.go` -- Preset type, PresetStore CRUD, conversion functions
- `internal/lab/override.go` -- Override detection, merge logic, diff-style rendering
- `internal/lab/state.go` -- StartConfig tracked on Metadata for `--from-lab` support
- `internal/commands/preset.go` -- All preset subcommands
- `internal/commands/start.go` -- Extended with optional positional preset arg

## Test plan

- [ ] 17 PresetStore unit tests (CRUD, validation, formatting, deep-copy)
- [ ] 26 override detection/rendering tests (merge, diff output, same-value skip, immutability)
- [ ] 5 StartConfig tracking tests (round-trip, backward compat, conversion)
- [ ] 14 preset save command tests
- [ ] 9 start-from-preset tests
- [ ] 12 preset list/show tests
- [ ] 5 preset delete tests
- [ ] 6 E2E integration tests (11 subtests) covering full user journeys